### PR TITLE
feat: add delay when refreshing to fix blank figure

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -88,6 +88,6 @@ from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg as _Figu
 _original_refresh_all = _FigureManagerWebAgg.refresh_all
 def _new_refresh_all(self):
     from time import sleep
-    sleep(0.01)
+    sleep(0.05)
     _original_refresh_all(self)
 _FigureManagerWebAgg.refresh_all = _new_refresh_all

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -80,3 +80,14 @@ except NameError:
 # Close all instruments when exiting QCoDeS
 import atexit
 atexit.register(Instrument.close_all)
+
+# Patch matplotlib webagg backend to add delay when refreshing.
+# Otherwise, any event (such as moving mouse over plot) can temporarily create
+# a blank figure. Adding a small sleep fixes this
+from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg as _FigureManagerWebAgg
+_original_refresh_all = _FigureManagerWebAgg.refresh_all
+def _new_refresh_all(self):
+    from time import sleep
+    sleep(0.01)
+    _original_refresh_all(self)
+_FigureManagerWebAgg.refresh_all = _new_refresh_all

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -86,8 +86,9 @@ atexit.register(Instrument.close_all)
 # a blank figure. Adding a small sleep fixes this
 from matplotlib.backends.backend_webagg_core import FigureManagerWebAgg as _FigureManagerWebAgg
 _original_refresh_all = _FigureManagerWebAgg.refresh_all
+_FigureManagerWebAgg._sleep_duration = 0.1
 def _new_refresh_all(self):
     from time import sleep
-    sleep(0.05)
+    sleep(self._sleep_duration)
     _original_refresh_all(self)
 _FigureManagerWebAgg.refresh_all = _new_refresh_all


### PR DESCRIPTION
Fixes #24 

Found out that MatPlot shows a blank screen when a `draw` event is fired from an interaction (e.g. a mouse moving over the plot). This caused a refresh_all command, which only can cause this blank screen when coming from an interaction event; If MatPlot itself requests a draw, everything is fine...

Somehow, adding a small sleep in refresh_all seems to solve the problem. Perhaps the messaging from the backend to frontend happens too fast?

Changes proposed in this pull request:
- Patched matplotlib.backends.backend_webagg_core.FigureManagerWebAgg.refresh_all to include a sleep
Patching occurs in the qCodes init