### PR TITLE
Feature/parameter node

### DIFF
--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -439,6 +439,11 @@ class DotDict(dict):
         except KeyError:
             raise AttributeError('Attribute {} not found'.format(key))
 
+    def __dir__(self):
+        # Add keys to dir, used for auto-completion
+        items = super().__dir__()
+        items.extend(self.keys())
+        return items
 
 def update(d, u):
     for k, v in u.items():

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -156,8 +156,8 @@ class _BaseParameter(Metadatable, DeferredOperations):
             JSON snapshot of the parameter
     """
 
-    def __init__(self, name: str,
-                 instrument: Optional['Instrument'],
+    def __init__(self, name: str = None,
+                 instrument: Optional['Instrument'] = None,
                  snapshot_get: bool=True,
                  metadata: Optional[dict]=None,
                  wrap_get: bool=True,
@@ -235,7 +235,7 @@ class _BaseParameter(Metadatable, DeferredOperations):
         # check if additional waiting time is needed before next set
         self._t_last_set = time.perf_counter()
 
-        self.log = logging.getLogger(str(self))
+
 
     def __str__(self):
         """Include the instrument name with the Parameter name if possible."""
@@ -261,6 +261,10 @@ class _BaseParameter(Metadatable, DeferredOperations):
             else:
                 raise NotImplementedError('no set cmd found in' +
                                           ' Parameter {}'.format(self.name))
+
+    @property
+    def log(self):
+        return logging.getLogger(str(self))
 
     def snapshot_base(self, update: bool=False,
                       params_to_skip_update: Sequence[str]=None) -> dict:
@@ -743,7 +747,7 @@ class Parameter(_BaseParameter):
 
     """
 
-    def __init__(self, name: str,
+    def __init__(self, name: str = None,
                  instrument: Optional['Instrument']=None,
                  label: Optional[str]=None,
                  unit: Optional[str]=None,

--- a/qcodes/instrument/parameter_node.py
+++ b/qcodes/instrument/parameter_node.py
@@ -1,0 +1,36 @@
+from qcodes.config.config import DotDict
+from qcodes.instrument.parameter import _BaseParameter
+
+class ParameterNode():
+    parameters = {}
+
+    def __init__(self):
+        self.parameters = DotDict()
+
+    def __call__(self) -> dict:
+        return self.parameters
+
+    def __getattr__(self, attr):
+        if attr in self.parameters:
+            return self.parameters[attr]()
+        else:
+            raise AttributeError(attr)
+
+    def __setattr__(self, attr, val):
+        if isinstance(val, _BaseParameter):
+            self.parameters[attr] = val
+            if val.name == 'None':
+                # Parameter created without name, update to attr
+                val.name = attr
+                if val.label is None:
+                    val.label = attr
+        elif attr in self.parameters:
+            self.parameters[attr](val)
+        else:
+            super().__setattr__(attr, val)
+
+    def __dir__(self):
+        # Add parameters to dir
+        items = super().__dir__()
+        items.extend(self.parameters.keys())
+        return items


### PR DESCRIPTION
Adds the ParameterNode, which is to be the replacement for InstrumentBase.
The ParameterNode will change how we access parameters, removing setting/getting using brackets.

I haven't yet replaced InstrumentBase, but added it separately. Looking for a review first @maij

## Creating a ParameterNode
Parameter nodes are instantiated via: `parameter_node = ParameterNode()

## Adding parameters
parameters can be added by setting an attribute:
`parameter_node.new_parameter = Parameter()`
Note that it is no longer necessary to specify a name in the Parameter. If it is not explicitly specified, it will be set to the attribute name

## Getting/setting parameter values
Getting and setting of parameters in a parameter node is now done same as you would any other attribute:
- Setting a value: `parameter_node.new_parameter = 42`
- Getting a value: `parameter_node.new_parameter` (returns 42)

## Accessing parameter object
The actual parameter can be accessed in two ways: 
1. `parameter_node.parameters.new_parameter` (`parameter_node.parameters` is a `DotDict`).
2. `parameter_node().new_parameter`, the call `()` will return `parameter_node.parameters`. 

The second method is more succinct, but does have one drawback, namely that autocomplete won't work with it. I haven't figured out another way of easily accessing parameters that does have autocomplete, or a way to add autocompletion to the call method.

## Additional change
- Parameter.log is now a dependent property, because a logger raises an error when copied.
- Change Parameter name to be optional ('None` by default)
- Add `__dir__` to `qc.config`, which allows auto-completion.