### PR TITLE
Feature: Parameter signals

### DIFF
--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -373,6 +373,9 @@ class Config():
 
     def __getitem__(self, name):
         val = self.current_config
+        if isinstance(name, int):
+            # When iterating through a dict, indices are passed instead
+            name = list(val)[name]
         for key in name.split('.'):
             val = val[key]
         return val

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -375,7 +375,7 @@ class Config():
         val = self.current_config
         if isinstance(name, int):
             # When iterating through a dict, indices are passed instead
-            name = list(val)[name]
+            return list(val)[name]
         for key in name.split('.'):
             val = val[key]
         return val

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -440,7 +440,7 @@ class DotDict(dict):
         try:
             return self.__getitem__(key)
         except KeyError:
-            raise AttributeError('Attribute {} not found'.format(key))
+            raise AttributeError(f'Attribute {key} not found')
 
 
 def update(d, u):

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -233,7 +233,7 @@ class _BaseParameter(Metadatable, SignalEmitter):
         self.__deepcopy__ = partial(__deepcopy__, self)
 
         Metadatable.__init__(self, metadata)
-        SignalEmitter.__init__(self)
+        SignalEmitter.__init__(self, initialize_signal=False)
         self.name = str(name)
         self._instrument = instrument
         self._snapshot_get = snapshot_get

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -102,12 +102,12 @@ class _BaseParameter(Metadatable, DeferredOperations):
         snapshot_value (Optional[bool]): False prevents parameter value to be
             stored in the snapshot. Useful if the value is large.
 
-        wrap_get (Optional[bool]): Wrap get method, adding features such as 
-            saving latest value, `val_mapping`, `get_parser`.  
+        wrap_get (Optional[bool]): Wrap get method, adding features such as
+            saving latest value, `val_mapping`, `get_parser`.
             Default True
-            
-        wrap_get (Optional[bool]): Wrap set method, adding features such as 
-            saving latest value, `val_mapping`, `set_parser`.  
+
+        wrap_get (Optional[bool]): Wrap set method, adding features such as
+            saving latest value, `val_mapping`, `set_parser`.
             Default True
 
         step (Optional[Union[int, float]]): max increment of parameter value.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -127,7 +127,7 @@ def __deepcopy__(self, memodict={}):
         self.signal = signal
 
 
-class _BaseParameter(Metadatable, DeferredOperations):
+class _BaseParameter(Metadatable):
     """
     Shared behavior for all parameters. Not intended to be used
     directly, normally you should use ``Parameter``, ``ArrayParameter``,

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -108,9 +108,11 @@ def __deepcopy__(self, memodict={}):
     """
     deepcopy_method = self.__deepcopy__
     log = self.log
+    signal = self.signal
     try:
         del self.__deepcopy__
         del self.log
+        self.signal = None
         self_copy = deepcopy(self)
         self_copy.__deepcopy__ = deepcopy_method
         self_copy.log = log
@@ -122,6 +124,7 @@ def __deepcopy__(self, memodict={}):
     finally:
         self.__deepcopy__ = deepcopy_method
         self.log = log
+        self.signal = signal
 
 
 class _BaseParameter(Metadatable, DeferredOperations):

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -309,8 +309,9 @@ class _BaseParameter(Metadatable, SignalEmitter):
         self.log = logging.getLogger(str(self))
 
         if config_link is not None:
-            if 'user' in config and hasattr(config.user, 'signal'):
-                config.user.signal.connect(self, sender=config_link)
+            if 'silq_config' in config.user and hasattr(config.user.silq_config, 'signal'):
+                config.user.silq_config.signal.connect(self._handle_config_signal,
+                                                       sender=config_link)
 
     def __copy__(self):
         return self.__deepcopy__()
@@ -339,6 +340,9 @@ class _BaseParameter(Metadatable, SignalEmitter):
             else:
                 raise NotImplementedError('no set cmd found in' +
                                           ' Parameter {}'.format(self.name))
+
+    def _handle_config_signal(self, sender, value):
+        self(value)
 
     def snapshot_base(self, update: bool=False,
                       params_to_skip_update: Sequence[str]=None) -> dict:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -227,7 +227,7 @@ class _BaseParameter(Metadatable, SignalEmitter):
                  snapshot_value: bool=True,
                  max_val_age: Optional[float]=None,
                  vals: Optional[Validator]=None,
-                 delay: Optional[Union[int, float]]=None
+                 delay: Optional[Union[int, float]]=None,
                  config_link: str = None):
         # Create __deepcopy__ in the object scope (see documentation for details)
         self.__deepcopy__ = partial(__deepcopy__, self)
@@ -309,11 +309,8 @@ class _BaseParameter(Metadatable, SignalEmitter):
         self.log = logging.getLogger(str(self))
 
         if config_link is not None:
-            try:
+            if 'user' in config and hasattr(config.user, 'signal'):
                 config.user.signal.connect(self, sender=config_link)
-            except:
-                logging.warning(f'Could not attach {self} to config path {config_link}')
-
 
     def __copy__(self):
         return self.__deepcopy__()

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -46,6 +46,10 @@ This file defines four classes of parameters:
     Note that it is not yet a subclass of BaseParameter.
 
 
+A callable can be attached to a parameter using `_BaseParameter.connect`.
+Every time the parameter changes value. the callable is called with the new
+value as an argument. This also allows other parameters to be updated every time
+the primary parameter changes value.
 """
 
 # TODO (alexcjohnson) update this with the real duck-typing requirements or
@@ -208,6 +212,10 @@ class _BaseParameter(Metadatable, SignalEmitter):
 
         metadata (Optional[dict]): extra information to include with the
             JSON snapshot of the parameter
+
+        config_link: optional silq config path, in which case every time
+            that the silq config item is updated, the parameter value is also
+            updated. Warning: SilQ only! See SilQ SubConfig for more info.
     """
 
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1037,3 +1037,8 @@ class TestParameterSignal(TestCase):
         self.assertEqual(self.source_parameter(), 1)
         self.assertEqual(self.target_parameter(), 123)
         self.assertEqual(self.second_target_parameter(), 123)
+
+    def test_config_link(self):
+        # Note that config links only work in silq, since it relies on the
+        # SubConfig, and so we only test here that it doesn't raise an error
+        config_parameter = Parameter('config', config_link='pulses.duration')

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -832,3 +832,20 @@ class TestInstrumentRefParameter(TestCase):
         self.d.close()
         del self.a
         del self.d
+
+
+class TestParameterSignal(TestCase):
+    def test_parameter_link_function(self):
+        source_parameter = Parameter(name='source', set_cmd=None,
+                                     initial_value=42)
+
+        args_kwargs_dict = {}
+        def save_args_kwargs(*args, **kwargs):
+            args_kwargs_dict['args'] = args
+            args_kwargs_dict['kwargs'] = kwargs
+
+        source_parameter.link(save_args_kwargs)
+
+        source_parameter(41)
+        self.assertEqual(args_kwargs_dict['args'], (41,))
+        self.assertEqual(args_kwargs_dict['kwargs'], {})

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -943,6 +943,6 @@ class TestParameterSignal(TestCase):
         self.assertEqual(self.source_parameter(), 42)
         self.assertEqual(self.target_parameter(), 43)
 
-        self.source_parameter(41)
-        self.assertEqual(self.target_parameter(), 41)
-        self.assertEqual(copied_source_parameter(), 42)
+        self.source_parameter(44)
+        self.assertEqual(self.target_parameter(), 44)
+        self.assertEqual(copied_source_parameter(), 41)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -946,3 +946,20 @@ class TestParameterSignal(TestCase):
         self.source_parameter(44)
         self.assertEqual(self.target_parameter(), 44)
         self.assertEqual(copied_source_parameter(), 41)
+
+    def test_circular_signalling(self):
+        self.set_calls = 0
+        def prevent_circular_signalling(val):
+            if self.set_calls > 10:
+                raise RecursionError('Too many set calls')
+
+        self.source_parameter = Parameter(name='source', set_cmd=None,
+                                          initial_value=42,
+                                          set_cmd=prevent_circular_signalling)
+
+        self.target_parameter = Parameter(name='target', set_cmd=None,
+                                          initial_value=43)
+
+        self.source_parameter.link(self.target_parameter)
+        self.target_parameter.link(self.source_parameter)
+

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -875,15 +875,15 @@ class TestParameterSignal(TestCase):
         self.target_parameter = Parameter(name='target', set_cmd=None,
                                           initial_value=43)
 
-    def test_parameter_link_function(self):
-        self.source_parameter.link(self.save_args_kwargs)
+    def test_parameter_connect_function(self):
+        self.source_parameter.connect(self.save_args_kwargs)
 
         self.source_parameter(41)
         self.assertEqual(self.args_kwargs_dict['args'], (41,))
         self.assertEqual(self.args_kwargs_dict['kwargs'], {})
 
-    def test_parameter_link_parameter(self):
-        self.source_parameter.link(self.target_parameter)
+    def test_parameter_connect_parameter(self):
+        self.source_parameter.connect(self.target_parameter)
         self.assertEqual(self.target_parameter(), 43)
 
         self.source_parameter(41)
@@ -899,8 +899,8 @@ class TestParameterSignal(TestCase):
         gc.collect()
         self.assertIsNone(target_ref())
 
-    def test_delete_linked_parameter(self):
-        self.source_parameter.link(self.target_parameter)
+    def test_delete_connected_parameter(self):
+        self.source_parameter.connect(self.target_parameter)
 
         target_ref = weakref.ref(self.target_parameter)
 
@@ -908,8 +908,8 @@ class TestParameterSignal(TestCase):
         gc.collect()
         self.assertIsNone(target_ref())
 
-    def test_delete_linked_parameter_set(self):
-        self.source_parameter.link(self.target_parameter)
+    def test_delete_connected_parameter_set(self):
+        self.source_parameter.connect(self.target_parameter)
         self.source_parameter(41)
         self.assertEqual(self.target_parameter(), 41)
 
@@ -922,7 +922,7 @@ class TestParameterSignal(TestCase):
         self.assertEqual(len(self.source_parameter.signal.receivers), 0)
 
     def test_deepcopied_source_parameter(self):
-        self.source_parameter.link(self.target_parameter)
+        self.source_parameter.connect(self.target_parameter)
         deepcopied_source_parameter = deepcopy(self.source_parameter)
 
         self.assertEqual(self.target_parameter(), 43)
@@ -935,7 +935,7 @@ class TestParameterSignal(TestCase):
         self.assertEqual(deepcopied_source_parameter(), 41)
 
     def test_copied_source_parameter(self):
-        self.source_parameter.link(self.target_parameter)
+        self.source_parameter.connect(self.target_parameter)
         copied_source_parameter = copy(self.source_parameter)
 
         self.assertEqual(self.target_parameter(), 43)
@@ -947,10 +947,9 @@ class TestParameterSignal(TestCase):
         self.assertEqual(self.target_parameter(), 44)
         self.assertEqual(copied_source_parameter(), 41)
 
-    def test_linked_parameter(self):
-        self.source_parameter.link(self.target_parameter)
+    def test_connected_parameter(self):
+        self.source_parameter.connect(self.target_parameter)
         copied_target_parameter = copy(self.target_parameter)
-        self.assertFalse(hasattr(copied_target_parameter, '_link'))
 
     def test_circular_signalling(self):
         self.set_calls = 0
@@ -967,10 +966,10 @@ class TestParameterSignal(TestCase):
                                           initial_value=43,
                                           set_cmd=prevent_circular_signalling)
 
-        self.source_parameter.link(self.target_parameter)
+        self.source_parameter.connect(self.target_parameter)
         self.source_parameter.signal.send(0)
 
-        self.target_parameter.link(self.source_parameter)
+        self.target_parameter.connect(self.source_parameter)
 
         self.set_calls = 0
 
@@ -984,31 +983,55 @@ class TestParameterSignal(TestCase):
         self.assertEqual(self.source_parameter(), 41)
         self.assertEqual(self.target_parameter(), 41)
 
-    def test_unlink_parameter(self):
-        self.source_parameter.link(self.target_parameter)
+    def test_connect_to_second_parameter(self):
+        self.source_parameter2 = Parameter('source2', initial_value=12,
+                                           set_cmd=None)
+
+        self.source_parameter.connect(self.target_parameter)
+        self.source_parameter2.connect(self.target_parameter)
+
+        self.source_parameter(1)
+        self.assertEqual(self.source_parameter(), 1)
+        self.assertEqual(self.source_parameter2(), 12)
+        self.assertEqual(self.target_parameter(), 1)
+
+        self.source_parameter2(2)
+        self.assertEqual(self.source_parameter(), 1)
+        self.assertEqual(self.source_parameter2(), 2)
+        self.assertEqual(self.target_parameter(), 2)
+
+        self.source_parameter2.disconnect(self.target_parameter)
+        self.source_parameter(3)
+        self.source_parameter2(4)
+        self.assertEqual(self.source_parameter(), 3)
+        self.assertEqual(self.source_parameter2(), 4)
+        self.assertEqual(self.target_parameter(), 3)
+
+    def test_disconnect_parameter(self):
+        self.source_parameter.connect(self.target_parameter)
 
         self.source_parameter(123)
         self.assertEqual(self.source_parameter(), 123)
         self.assertEqual(self.target_parameter(), 123)
 
-        self.source_parameter.unlink(self.target_parameter)
+        self.source_parameter.disconnect(self.target_parameter)
 
         self.source_parameter(1)
         self.assertEqual(self.source_parameter(), 1)
         self.assertEqual(self.target_parameter(), 123)
 
-    def test_triple_linked_parameters(self):
+    def test_triple_connected_parameters(self):
         self.second_target_parameter = Parameter('p3', initial_value=40,
                                                  set_cmd=None)
-        self.source_parameter.link(self.target_parameter)
-        self.target_parameter.link(self.second_target_parameter)
+        self.source_parameter.connect(self.target_parameter)
+        self.target_parameter.connect(self.second_target_parameter)
 
         self.source_parameter(123)
         self.assertEqual(self.source_parameter(), 123)
         self.assertEqual(self.target_parameter(), 123)
         self.assertEqual(self.second_target_parameter(), 123)
 
-        self.source_parameter.unlink(self.target_parameter)
+        self.source_parameter.disconnect(self.target_parameter)
 
         self.source_parameter(1)
         self.assertEqual(self.source_parameter(), 1)

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -584,8 +584,9 @@ class SignalEmitter:
     callables are called with the respective args and kwargs.
 
     Args:
-        callable: Callable, to be called whenever SignalEmitter.signal.send is
-            triggered. Can be another SignalEmitter.
+        initialize_signal: instantiate a blnker.Signal object. If set to False,
+            self.Signal needs to be set later on. This could be useful when you
+            want a single Signal that is shared by all class instances.
 
     Note:
         The SignalEmitter has protection against infinite recursions resulting
@@ -593,10 +594,10 @@ class SignalEmitter:
         of the signal chain. However, it does not protect against infinite
         recursions from signals sent from objects that are not signal emitters.
     """
-    # Signal used for connecting to parameter via Parameter.connect method
+    # Signal used for connecting to parameter via SignalEmitter.connect method
     signal = None
 
-    def __init__(self, initialize_signal=True):
+    def __init__(self, initialize_signal: bool=True):
         self._signal_chain = []
         if initialize_signal:
             self.signal = Signal()

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -596,9 +596,10 @@ class SignalEmitter:
     # Signal used for connecting to parameter via Parameter.connect method
     signal = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, initialize_signal=True):
         self._signal_chain = []
-        super().__init__(*args, **kwargs)
+        if initialize_signal:
+            self.signal = Signal()
 
     def connect(self, callable):
         """Connect a callable, which can be another SignalEmitter.

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -6,7 +6,6 @@ class Metadatable:
     def __init__(self, metadata=None):
         self.metadata = {}
         self.load_metadata(metadata or {})
-        super().__init__()
 
     def load_metadata(self, metadata):
         """

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -6,6 +6,7 @@ class Metadatable:
     def __init__(self, metadata=None):
         self.metadata = {}
         self.load_metadata(metadata or {})
+        super().__init__()
 
     def load_metadata(self, metadata):
         """

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(name='qcodes',
           'h5py>=2.6',
           'websockets>=3.2,<3.4',
           'jsonschema',
-          'pyperclip'
+          'pyperclip',
+          'blinker'
       ],
 
       test_suite='qcodes.tests',


### PR DESCRIPTION
Adds signals to parameters, allows ancillary functions/parameter set when a parameter's value is modified.

# Changes:
- Add `Parameter.link` method, which takes a callable as argument. Every time `parameter.set` is called, the value is passed to the callable.

# Open questions
- What is correct way to handle copying a parameter? How does copying affect the signal?
  The signal is removed prior to copying and added again after. This ensures no errors occur.
- How should we disconnect a parameter. Does weakreferencing work / are linked parameters never gc'ed?
  Garbage collection seems to work fine.
- How should we link a parameter to a config item?
  
- Should a link perform an initial set?
  I don't think so. We might want to connect it to the config, but already have an initial value setup.


# Todo:
- [x] Check that copying a parameter handles Parameter.signal correctly. 
- [x] Proper handling of disconnect, also when a parameter is deleted.
- [x] Allow connecting a parameter to the config.
- [x] Ensure no circular parameter setting. Use a signal_chain
- [x] Add documentation

# Notes:
- See Pulse for inspiration