### PR TITLE
Add ParameterNode.parent

### DIFF
--- a/qcodes/tests/test_parameter_node.py
+++ b/qcodes/tests/test_parameter_node.py
@@ -60,6 +60,15 @@ class TestParameterNode(TestCase):
         parameter_node.nested.param = 42
         self.assertEqual(parameter_node.nested.param, 42)
 
+    def test_nested_parameter_node_snapshot_with_parent(self):
+        parameter_node = ParameterNode(use_as_attributes=True)
+        nested_parameter_node = ParameterNode(use_as_attributes=True)
+        parameter_node.nested = nested_parameter_node
+
+        nested_parameter_node.parent = parameter_node
+        nested_parameter_node.snapshot()
+
+
     def test_parameter_node_nested_explicit_name(self):
         parameter_node = ParameterNode(use_as_attributes=True)
         nested_explicit_parameter_node = ParameterNode(name='explicit_name',


### PR DESCRIPTION
ToDo
- [x] Special treatment of `parent=False` (also for Parameter)
- [x] Add test for `parent=False`
- [x] Special treatment of `parent` during `__setattr__`
- [x] Attach parent node as `parent` during `__setattr__`
- [x] Add documentation on 'parent'
- [x] Handle copying, including tests
- [x] Check if copied nodes can be copied