### PR TITLE
Fix/parameter node copying

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -118,7 +118,8 @@ def __deepcopy__(self, memodict={}):
         is faster and creates a shallow copy.
     """
     restore_attrs = {}
-    for attr in ['__deepcopy__', '__getstate__','signal', 'get', 'set', 'parent']:
+    for attr in ['__deepcopy__', '__getstate__','signal', 'get', 'set',
+                 'parent', 'sender']:
         if attr in self.__dict__:
             restore_attrs[attr] = getattr(self, attr)
 
@@ -131,12 +132,14 @@ def __deepcopy__(self, memodict={}):
     try:
         for attr in {**restore_attrs, **node_decorator_methods}:
             delattr(self, attr)
+        self.parent = None  # Deepcopying a parameter sometimes needs a parent
 
         self_copy = deepcopy(self)
         self_copy.__deepcopy__ = partial(__deepcopy__, self_copy)
         self_copy.__getstate__ = partial(__getstate__, self_copy)
 
         self_copy.parent = None
+        self_copy.sender = None
         self_copy.signal = Signal()
 
         # Detach and reattach all node decorator methods, now containing

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1322,7 +1322,6 @@ class TestCopyParameterCount(TestCase):
     deepcopy_list = []
 
     def deepcopy_wrapped(self, x):
-        print('\nhi there, about to deepcopy', x)
         self.deepcopy_list.append(x)
         return copy.deepcopy(x)
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1360,6 +1360,7 @@ class ListHandler(logging.Handler):  # Inherit from logging.Handler
     def __init__(self, log_list):
         # run the regular Handler __init__
         logging.Handler.__init__(self)
+        self.setLevel(logging.DEBUG)
         # Our custom argument
         self.log_list = log_list
 
@@ -1370,7 +1371,9 @@ class ListHandler(logging.Handler):  # Inherit from logging.Handler
 
 class TestParameterLogging(TestCase):
     def setUp(self):
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+        logger = logging.getLogger()
+        logger.level = logging.DEBUG
         self.log_list = []
         self.handler = ListHandler(self.log_list)
         logging.getLogger().addHandler(self.handler)

--- a/qcodes/tests/test_parameter_node.py
+++ b/qcodes/tests/test_parameter_node.py
@@ -610,6 +610,7 @@ class TestCombinedParameterAndParameterNode(TestCase):
         self.assertSetEqual(overlapping_attrs,
                             {'__init__', '_meta_attrs', '__doc__', '__module__',
                              'metadata', '__deepcopy__', 'name', '__getitem__',
+                             '__getstate__',
                              'log_changes', 'sweep', 'parent', 'get'})
 
     def test_create_multiple_inheritance_initialization(self):


### PR DESCRIPTION
Fixes two bugs related to the ParameterNode. Also added tests and fixed some older tests that started raising errors

First, deepcopying a parameter of a Parameternode sometimes caused an error, in particular when the parameter had properties that were decorated from the ParameterNode.
The error raised is that the parameter does not have a parent.
The issue is solved by setting `parameter.parent = None` during the copying.

Second, copying a Parameter of a ParameterNode also sometimes causes a copy of the entire ParameterNode, in particular when the parameter was linked to another parameter.
The issue is solved by explicitly setting `sender = None`.

These errors were particularly relevant for pulses in Pulse Sequences, where targeting a PulseSequence could result in many unnecessary copies of the pulses.

@maij 

