### PR TITLE
Update Matplot to set 2D color limits via mesh

### DIFF
--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -183,7 +183,7 @@ class BasePlot:
         name = (getattr(data_array, 'label', '') or
                 getattr(data_array, 'name', ''))
         unit = getattr(data_array, 'unit', '')
-        return  name, unit
+        return name, unit
 
     @staticmethod
     def expand_trace(args, kwargs):


### PR DESCRIPTION
Newer versions of matplotlib are deprecating setting a 2D color limit via `ax.colorbar.set_clim`.
This PR changes the behaviour of MatPlot such that the limit is set via the mesh.

Additionally, the color limits are automatically updated for all 2D images when a new image is added.

Also fix a really minor bug where `nbins` is not always passed on