### PR TITLE
Fix: ensure matplot is fully redrawn every update

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -318,6 +318,10 @@ class MatPlot(BasePlot):
                         ax.dataLim = bbox
                 ax.autoscale()
 
+        # Set internal flag to ensure that the full figure is redrawn.
+        # If unset, calling canvas.draw from a separate thread may not draw
+        # all components
+        self.fig.canvas._force_full = True
         self.fig.canvas.draw()
 
     def _draw_plot(self, ax, y, x=None, fmt=None, subplot=1,

--- a/qcodes/utils/threading.py
+++ b/qcodes/utils/threading.py
@@ -99,15 +99,15 @@ class UpdaterThread(threading.Thread):
                 logger.warning(f'Found {active_threads} active updater threads')
 
         if auto_start:
-            time.sleep(interval)
             self.start()
 
     def run(self):
         while not self._is_stopped:
+            time.sleep(self.interval)
             if not self._is_paused:
                 for callable in self.callables:
                     callable()
-            time.sleep(self.interval)
+                    print(f'executed {callable}')
         else:
             logger.warning('Updater thread stopped')
 

--- a/qcodes/utils/threading.py
+++ b/qcodes/utils/threading.py
@@ -107,7 +107,6 @@ class UpdaterThread(threading.Thread):
             if not self._is_paused:
                 for callable in self.callables:
                     callable()
-                    print(f'executed {callable}')
         else:
             logger.warning('Updater thread stopped')
 


### PR DESCRIPTION
When updated from a separate thread, matplot would sometimes not redraw the entire figure.