### PR TITLE
Feature/tools to run code/function in separate thread

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -69,28 +69,23 @@ from qcodes.utils import validators
 
 from qcodes.instrument_drivers.test import test_instruments, test_instrument
 
-try:
-    from IPython import get_ipython
-    get_ipython()
-    # if get_ipython() is not None: # Check if we are in iPython
-    from qcodes.utils.magic import register_magic_class
-    register_magic = config.core.get('register_magic', False)
-    if register_magic is not False:
-        register_magic_class(magic_commands=register_magic)
-except RuntimeError as e:
-    print(e)
+from qcodes.utils.threading import new_job, job_manager, active_job
+
+# Register IPython magics
+from qcodes.utils.helpers import using_ipython as _using_ipython
+if _using_ipython():
+    try:
+        # if get_ipython() is not None: # Check if we are in iPython
+        from qcodes.utils.magic import register_magic_class
+        register_magic = config.core.get('register_magic', False)
+        if register_magic is not False:
+            register_magic_class(magic_commands=register_magic)
+    except RuntimeError as e:
+        print('Could not register QCoDeS magics.\nError:', e)
 
 # Close all instruments when exiting QCoDeS
 import atexit
 atexit.register(Instrument.close_all)
-
-
-# Add measurement jobs, called via %%measurement_thread
-# See qcodes.utils.magic.QCoDeSMagic.measurement_thread for details.
-# The measurement refers to silq.tools.loop_tools.Measurement
-from IPython.lib import backgroundjobs as bg
-measurement_jobs = bg.BackgroundJobManager()
-measurement_job = None
 
 
 def register_IPython_In_out():

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -69,7 +69,7 @@ from qcodes.utils import validators
 
 from qcodes.instrument_drivers.test import test_instruments, test_instrument
 
-from qcodes.utils.threading import new_job, job_manager, active_job
+from qcodes.utils.threading import new_job, job_manager, active_job, last_active_job
 
 # Register IPython magics
 from qcodes.utils.helpers import using_ipython as _using_ipython

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -84,6 +84,15 @@ except RuntimeError as e:
 import atexit
 atexit.register(Instrument.close_all)
 
+
+# Add measurement jobs, called via %%measurement_thread
+# See qcodes.utils.magic.QCoDeSMagic.measurement_thread for details.
+# The measurement refers to silq.tools.loop_tools.Measurement
+from IPython.lib import backgroundjobs as bg
+measurement_jobs = bg.BackgroundJobManager()
+measurement_job = None
+
+
 def register_IPython_In_out():
     """ Register IPython's In and Out such that it can be saved"""
     import builtins

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -469,6 +469,45 @@ def using_ipython() -> bool:
     return hasattr(builtins, '__IPYTHON__')
 
 
+def define_func_from_string(func_name: str, code: str, shell: bool = True):
+    """Define a function from code passed as a string
+
+    If using IPython, the function will be defined as if a cell was executed.
+    Currently the function cannot accept args and/or kwargs as input.
+
+    Args:
+        func_name: Name of function to be defined
+        code: Code to be placed into function
+        shell: Whether to define function through an IPython cell.
+            If IPython is not used or shell=False, the function is defined
+            using exec() in the global namespace
+
+    Returns:
+        Handle to the defined function
+
+    Examples:
+        >>> code = "print('hi')"
+        >>> define_func_from_string('hi_func', code)
+        >>> hi_func()
+        ... hi
+
+    """
+    code_lines = code.split('\n')
+    indented_code_lines = ['    ' + line for line in code_lines]
+    indented_code = '\n'.join(indented_code_lines)
+
+    function_code = f'def {func_name}():\n' + indented_code
+
+    if shell and using_ipython():
+        from IPython import get_ipython
+        shell = get_ipython()
+        shell.run_cell(function_code, store_history=True, silent=True)
+    else:
+        exec(function_code, globals())
+
+    return eval(func_name)
+
+
 def foreground_qt_window(window):
     """
     Try as hard as possible to bring a qt window to the front. This

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -505,7 +505,7 @@ def define_func_from_string(func_name: str, code: str, shell: bool = True):
     else:
         exec(function_code, globals())
 
-    return eval(func_name)
+    return eval(func_name, globals())
 
 
 def foreground_qt_window(window):

--- a/qcodes/utils/threading.py
+++ b/qcodes/utils/threading.py
@@ -183,6 +183,20 @@ def active_job() -> Union[bg.BackgroundJobExpr, None]:
     except StopIteration:
         return None
 
+def last_active_job() -> Union[bg.BackgroundJobExpr, None]:
+    """Return last active job.
+    This job must have been created by `new_job` with kwarg ``active=True``, but
+    does not need to be running anymore.
+
+    Returns:
+        last active job if it ever existed, else None
+    """
+    try:
+        jobs = list(job_manager.all.values())
+        return next(job for job in reversed(jobs) if job.is_active)
+    except StopIteration:
+        return None
+
 
 def new_job(
     function, name: str = None, active: bool = True, *args, **kwargs

--- a/qcodes/utils/threading.py
+++ b/qcodes/utils/threading.py
@@ -8,13 +8,14 @@ import ctypes
 import time
 from collections import Iterable
 import logging
-
+from IPython.lib import backgroundjobs as bg
+from typing import Union
 
 logger = logging.getLogger(__name__)
 
 
 class RespondingThread(threading.Thread):
-    '''
+    """
     a Thread subclass for parallelizing execution. Behaves like a
     regular thread but returns a value from target, and propagates
     exceptions back to the main thread when this value is collected.
@@ -28,7 +29,8 @@ class RespondingThread(threading.Thread):
     thread.start()
     # do other things while this is running
     out = thread.output()  # out is 4
-    '''
+    """
+
     def __init__(self, target=None, args=(), kwargs={}, *args2, **kwargs2):
         super().__init__(*args2, **kwargs2)
 
@@ -56,7 +58,7 @@ class RespondingThread(threading.Thread):
 
 
 def thread_map(callables, args=None, kwargs=None):
-    '''
+    """
     Evaluate a sequence of callables in separate threads, returning
     a list of their return values.
 
@@ -67,13 +69,15 @@ def thread_map(callables, args=None, kwargs=None):
         kwargs (optional): a sequence of dicts containing the keyword arguments
             for each callable
 
-    '''
+    """
     if args is None:
         args = ((),) * len(callables)
     if kwargs is None:
         kwargs = ({},) * len(callables)
-    threads = [RespondingThread(target=c, args=a, kwargs=k)
-               for c, a, k in zip(callables, args, kwargs)]
+    threads = [
+        RespondingThread(target=c, args=a, kwargs=k)
+        for c, a, k in zip(callables, args, kwargs)
+    ]
 
     for t in threads:
         t.start()
@@ -82,8 +86,9 @@ def thread_map(callables, args=None, kwargs=None):
 
 
 class UpdaterThread(threading.Thread):
-    def __init__(self, callables, interval, name=None, max_threads=None,
-                 auto_start=True):
+    def __init__(
+        self, callables, interval, name=None, max_threads=None, auto_start=True
+    ):
         super().__init__(name=name)
         self._is_paused = False
 
@@ -93,10 +98,11 @@ class UpdaterThread(threading.Thread):
 
         self.interval = interval
         if max_threads is not None:
-            active_threads = sum(thread.getName()==name
-                                 for thread in threading.enumerate())
-            if  active_threads > max_threads:
-                logger.warning(f'Found {active_threads} active updater threads')
+            active_threads = sum(
+                thread.getName() == name for thread in threading.enumerate()
+            )
+            if active_threads > max_threads:
+                logger.warning(f"Found {active_threads} active updater threads")
 
         if auto_start:
             time.sleep(interval)
@@ -109,7 +115,7 @@ class UpdaterThread(threading.Thread):
                     callable()
             time.sleep(self.interval)
         else:
-            logger.warning('Updater thread stopped')
+            logger.warning("Updater thread stopped")
 
     def pause(self):
         self._is_paused = True
@@ -121,8 +127,9 @@ class UpdaterThread(threading.Thread):
         self._is_stopped = True
 
 
-def raise_exception_in_thread(thread: threading.Thread,
-                              exception_type: BaseException = SystemExit):
+def raise_exception_in_thread(
+    thread: threading.Thread, exception_type: BaseException = SystemExit
+):
     """Raises an exception in a thread, usually forcing it to terminate.
 
     Note that this can fail if the thread is in a try/except statement, causing
@@ -139,8 +146,8 @@ def raise_exception_in_thread(thread: threading.Thread,
     for tid, tobj in threading._active.items():
         if tobj is thread:
             res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
-                tid,
-                ctypes.py_object(exception_type))
+                tid, ctypes.py_object(exception_type)
+            )
             if res == 0:
                 raise ValueError("nonexistent thread id")
             elif res > 1:
@@ -156,3 +163,70 @@ class KillableThread(threading.Thread):
         # must raise the SystemExit type, instead of a SystemExit() instance
         # due to a bug in PyThreadState_SetAsyncExc
         raise_exception_in_thread(self, SystemExit)
+
+
+default_job_name = "_measurement"
+allow_duplicate_jobs = False
+job_manager = bg.BackgroundJobManager()
+
+
+def active_job() -> Union[bg.BackgroundJobExpr, None]:
+    """Return active job.
+    This job must have been created by `new_job` with kwarg ``active=True``, and
+    must still be running
+
+    Returns:
+        active job if it exists, else None
+    """
+    try:
+        return next(job for job in job_manager.running if job.is_active)
+    except StopIteration:
+        return None
+
+
+def new_job(
+    function, name: str = None, active: bool = True, *args, **kwargs
+) -> bg.BackgroundJobFunc:
+    """Run a function in a separate thread
+    The thread is an IPython job, which has additional features that extend the
+    default threading.Thread functionality. For instance, IPython jobs are
+    registered via a job manager (see above)
+
+    Args:
+        function: Function to be called
+        name: Thread name. If not set, ``default_job_name`` is used (see above)
+        active: Whether to make the job active. If True, the function
+            `active_job` will return this job if it is still running.
+            There can only be one active job at the same time.
+        *args: Optional args to be passed to the function
+        **kwargs: Optional kwargs to be passed to the function
+
+    Returns:
+        Newly created job
+
+    Note:
+        The job attribute ``is_active`` is added to the job after creation.
+        The method ``terminate`` is added to the job after creation. This method
+        is not foolproof (see `raise_exception_in_thread`).
+    """
+    if not name:
+        name = default_job_name
+
+    # Ensure thread does not already exist if allow_duplicate_threads = False
+    if not allow_duplicate_jobs:
+        existing_thread_names = [thread.name for thread in threading.enumerate()]
+        if name in existing_thread_names:
+            raise RuntimeError(f"Thread '{name}' already exists. Exiting")
+
+    # Run thread as an IPython job, registered in the job manager
+    job = job_manager.new(function, *args, kw=kwargs)
+
+    job.name = name  # Thread name can only be set after the job has been created
+
+    # Optionally register current job as active job
+    job.is_active = active
+
+    # Add terminate method
+    job.terminate = lambda: raise_exception_in_thread(job)
+
+    return job

--- a/qcodes/widgets/widgets.py
+++ b/qcodes/widgets/widgets.py
@@ -6,7 +6,7 @@ from ipywidgets.widgets import *
 from traitlets import Unicode, Bool
 
 import qcodes as qc
-from qcodes.utils.threading import UpdaterThread
+from qcodes.utils.threading import UpdaterThread, raise_exception_in_thread
 
 
 class LoopManagerWidget(DOMWidget):
@@ -64,7 +64,7 @@ class LoopManagerWidget(DOMWidget):
     def force_stop_loop(self, *args, **kwargs):
         for thread in threading.enumerate():
             if thread.name == 'qcodes_loop':
-                thread.terminate()
+                raise_exception_in_thread(thread)
 
     def update_widget(self):
         try:


### PR DESCRIPTION
IPython jobs are used for the threads. These have some nice features, such as being able to look at the traceback.

## Creating a new job

### Sending a function
```Python
from time import sleep
def fun():
    for k in range(5):
        sleep(1)
        print('at iteration', k)

qc.new_job(fun)
```

### Using magic
run this in a cell
```Python
%%new_job
from time import sleep
for k in range(5):
    sleep(1)
    print('at iteration', k)
```

## Accessing jobs
Jobs can be accessed via `qc.job_manager`, and the currently active job via `qc.active_job()`.
The last active job (which may be completed/crashed) can be accessed via `qc.last_active_job`
