### PR TITLE
feat: get data set arrays via getitem

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -201,6 +201,13 @@ class DataSet(DelegateAttributes):
             for array in self.arrays.values():
                 array.init_data()
 
+    def __getitem__(self, key):
+        return self.arrays[key]
+
+    def _ipython_key_completions_(self):
+        """Tab completion for IPython, i.e. the data arrays """
+        return self.arrays.keys()
+
     def sync(self):
         """
         Synchronize this DataSet with the DataServer or storage.


### PR DESCRIPTION
Allow easy access to data arrays in a dataset via getitem.

If a dataset contains an array `EPR.up_proportions`, it can be accessed via
`dataset['EPR.up_proportions']`

Note that because it contains a `.`, it cannot be accessed as an attribute
Should be good to go