### PR TITLE
Feature/parameter node updates

### DIFF
--- a/qcodes/instrument/parameter_node.py
+++ b/qcodes/instrument/parameter_node.py
@@ -448,6 +448,24 @@ class ParameterNode(Metadatable, DelegateAttributes, metaclass=ParameterNodeMeta
 
         return snap
 
+    def to_dict(self, get_latest=True):
+        if get_latest:
+            parameters_dict = {
+                name: parameter.get_latest() for name, parameter in self.parameters.items()
+            }
+        else:
+            parameters_dict = {
+                name: parameter() for name, parameter in self.parameters.items()
+            }
+
+        parameter_nodes_dict = {
+            name: parameter_node.to_dict(get_latest=get_latest)
+            for name, parameter_node in self.parameter_nodes.items()
+        }
+
+        combined_dict = {**parameters_dict, **parameter_nodes_dict}
+        return combined_dict
+
     def matches_parameter_node(self,
                                 other: Any,
                                 exclude_parameters: List[str] = [],

--- a/qcodes/instrument/parameter_node.py
+++ b/qcodes/instrument/parameter_node.py
@@ -476,6 +476,12 @@ class ParameterNode(Metadatable, DelegateAttributes, metaclass=ParameterNodeMeta
             parameters_dict = {
                 name: parameter() for name, parameter in self.parameters.items()
             }
+        for key, val in parameters_dict.items():
+            if isinstance(val, (list, tuple)):
+                parameters_dict[key] = [
+                    elem if not isinstance(elem, ParameterNode) else elem.to_dict()
+                    for elem in val
+                ]
 
         parameter_nodes_dict = {
             name: parameter_node.to_dict(get_latest=get_latest)

--- a/qcodes/instrument/parameter_node.py
+++ b/qcodes/instrument/parameter_node.py
@@ -467,7 +467,21 @@ class ParameterNode(Metadatable, DelegateAttributes, metaclass=ParameterNodeMeta
 
         return snap
 
-    def to_dict(self, get_latest=True):
+    def to_dict(self, get_latest: bool = True) -> Dict:
+        """Generate a dictionary representation of the parameter node
+
+        This method is similar to `ParameterNode.snapshot()`, but more compact.
+        Basically, every key is a parameter/parameternode name.
+        For a Parameter, the dict value is the parameter's value
+        For a ParameterNode, the value is another nested dict.
+
+        Args:
+            get_latest: Whether to add the latest value of a parameter,
+                or perform a parameter.get() to get the value.
+
+        Returns:
+            Dictionary representation of the parameter node
+        """
         if get_latest:
             parameters_dict = {
                 name: parameter.get_latest() for name, parameter in self.parameters.items()

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -716,10 +716,11 @@ class SignalEmitter:
         if isinstance(callable, SignalEmitter):
             callable = callable._signal_call
 
-        for receiver_ref in list(self.signal.receivers.values()):
-            receiver = receiver_ref()
-            if receiver == callable:
-                self.signal.disconnect(callable)
+        if getattr(self, 'signal', None) is not None:
+            for receiver_ref in list(self.signal.receivers.values()):
+                receiver = receiver_ref()
+                if receiver == callable:
+                    self.signal.disconnect(callable)
 
     def _signal_call(self, sender, *args, **kwargs):
         """Method that is called instead of standard __call__ for SignalEmitters

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -467,7 +467,7 @@ class MultiType(Validator):
         self._valid_values = []
         for val in self._validators:
             self._valid_values += val._valid_values
-        self._valid_values = list(set(self._valid_values))
+        self._valid_values = list(self._valid_values)
 
     def validate(self, value, context=''):
         args = ()


### PR DESCRIPTION
Adds several additions to the ParameterNode

- `ParameterNode.to_dict()` which generates a simple key: value pair for the parameternode.  
  It's similar to `snapshot()`, but more compact (only names and values).
  Also allows nested parameter nodes
- Add skipped parameters to `ParameterNode.deepcopy`
- Allow automatic setting of parameter when connecting to a config link