### PR TITLE
feat: only add parent name if it exists and is not none

### DIFF
--- a/qcodes/instrument/parameter_node.py
+++ b/qcodes/instrument/parameter_node.py
@@ -157,8 +157,8 @@ class ParameterNode(Metadatable, DelegateAttributes, metaclass=ParameterNodeMeta
     def __str__(self):
         s = ''
         if getattr(self, 'name', None):
-            if self.parent:
-                s += f'{self.parent}_'
+            if self.parent and getattr(self.parent, 'name', None) not in [None, '']:
+                s += f'{self.parent.name}_'
             if isinstance(self.name, _BaseParameter):
                 s += f'{self.name()}'
             else:


### PR DESCRIPTION
When the string representation of a parameter node is requested, it will also include the name of its parent node if it exists.
However, there are situations where the parent doesn't have a name. In this case, the code used to display the entire string representation, which could get messy.
The main example is a pulse sequence, which doesn't usually have a name.

Ready for review