### PR TITLE
ATS parameters now use get_raw instead of get

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -874,7 +874,7 @@ class AlazarParameter(Parameter):
 
         self._set(value)
 
-    def get(self):
+    def get_raw(self):
         """
         This method returns the name of the value set for this parameter
         :return: value
@@ -1268,7 +1268,7 @@ class ATSAcquisitionParameter(MultiParameter):
         # Ignore setter since getter is extracted from acquisition controller
         pass
 
-    def get(self):
+    def get_raw(self):
         return self.acquisition_controller.do_acquisition()
 
 


### PR DESCRIPTION
This stops a warning from being raised

Should be good to go