### PR TITLE
Remove clim kwarg from line plots

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -351,6 +351,9 @@ class MatPlot(BasePlot):
         if 'label' not in kwargs and isinstance(y, DataArray):
             kwargs['label'] = y.label
 
+        for lineplot_kwarg in ['clim']:
+            kwargs.pop(lineplot_kwarg, None)
+
         # NOTE(alexj)stripping out subplot because which subplot we're in is
         # already described by ax, and it's not a kwarg to matplotlib's ax.plot.
         # But I didn't want to strip it out of kwargs earlier because it should


### PR DESCRIPTION
This PR ignores the plot kwarg `clim` for line plots.
It is useful in circumstances such as the following:

```
arr_2D = np.zeros((5,5))
arr_1D = np.zeros(5)
MatPlot(arr_2D, arr_1D, clim=(0, 1))
```
In this case, clim is only used for the 2D array, and ignored for the 1D array. Otherwise an error would be raised