### PR TITLE
Remove MetaDatable as Station base class

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -27,8 +27,11 @@ if plotlib in {'matplotlib', 'all'}:
               'try "from qcodes.plots.qcmatplotlib import MatPlot" '
               'to see the full error')
 
-
+# Initialize singleton station
 from qcodes.station import Station
+station = Station()
+
+
 from qcodes.loops import Loop, active_measurement, active_dataset, stop, pause, resume
 from qcodes.measure import Measure
 from qcodes.actions import Task, Wait, BreakIf, ContinueIf, SkipIf

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -12,7 +12,7 @@ from qcodes.actions import _actions_snapshot
 
 
 @singleton
-class Station(Metadatable, ParameterNode):
+class Station(ParameterNode):
 
     """
     A representation of the entire physical setup.

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -46,6 +46,8 @@ class Station(ParameterNode):
 
         self.default_measurement = []
 
+        Station.default = self
+
     def snapshot_base(self, update=False):
         """
         State of the station as a JSON-compatible dict.


### PR DESCRIPTION
The fact that Station was inheriting from MetaDatable and ParameterNode (which also inherits from MetaDatable) was causing a method resolution order error.

Should be good to go