### PR TITLE
Remove unnecessary instrument values

### DIFF
--- a/qcodes/instrument_drivers/Keysight/Keysight_81180A.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_81180A.py
@@ -334,6 +334,7 @@ class AWGChannel(InstrumentChannel):
             initial_value=[],
             vals=vals.Lists(),
             docstring="List of uploaded waveforms",
+            snapshot_value=False
         )
 
         self.add_parameter(

--- a/qcodes/instrument_drivers/spincore/PulseBlasterDDS_II_300.py
+++ b/qcodes/instrument_drivers/spincore/PulseBlasterDDS_II_300.py
@@ -134,7 +134,8 @@ class PulseBlasterDDS(Instrument):
         self.add_parameter('instruction_sequence',
                            set_cmd=None,
                            initial_value=[],
-                           vals=Lists())
+                           vals=Lists(),
+                           snapshot_value=False)
 
         # Initialize the DDS
         self.setup(initialize=initialize)

--- a/qcodes/instrument_drivers/spincore/PulseBlasterESRPRO.py
+++ b/qcodes/instrument_drivers/spincore/PulseBlasterESRPRO.py
@@ -84,7 +84,9 @@ class PulseBlasterESRPRO(Instrument):
         self.add_parameter('instruction_sequence',
                            set_cmd=None,
                            initial_value=[],
-                           vals=vals.Anything())
+                           vals=vals.Anything(),
+                           snapshot_value=False
+                           )
 
         self.setup(initialize=True)
 


### PR DESCRIPTION
The 81180A and pulseblasters were adding unnecessary values to the snapshot.
This is in particular detrimental for the 81180A, which included it's uploaded waveforms