### PR TITLE
Parameter initial value should not override config value

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1160,7 +1160,6 @@ class Parameter(_BaseParameter):
                     f'Cannot pass initial value {initial_value} to {self} '
                     f'if it should also update its value from config {config_link}'
                 )
-                pass
             elif hasattr(self, 'set') and self.wrap_set:
                 self.set(initial_value, evaluate=False)
             else:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1156,7 +1156,10 @@ class Parameter(_BaseParameter):
                     and kwargs.get('update_from_config')
                     and self._latest['value'] is not None
             ):
-                # Initial value is already set from config
+                raise ValueError(
+                    f'Cannot pass initial value {initial_value} to {self} '
+                    f'if it should also update its value from config {config_link}'
+                )
                 pass
             elif hasattr(self, 'set') and self.wrap_set:
                 self.set(initial_value, evaluate=False)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1151,7 +1151,14 @@ class Parameter(_BaseParameter):
         self.unit = unit if unit is not None else ''
 
         if initial_value is not None:
-            if hasattr(self, 'set') and self.wrap_set:
+            if (
+                    'config_link' in kwargs
+                    and kwargs.get('update_from_config')
+                    and self._latest['value'] is not None
+            ):
+                # Initial value is already set from config
+                pass
+            elif hasattr(self, 'set') and self.wrap_set:
                 self.set(initial_value, evaluate=False)
             else:
                 # No set function defined, so create a wrapper function


### PR DESCRIPTION
Previously if a parameter was supposed to get it's value from the config, it would be overridden by any initial value.
Example:
```
silq.config.analysis.t_read = 1e-3
p = Parameter('t_read', config_link='analysis.t_read', update_from_config=True, initial_value=2e-3)
p()
>>> 2e-3
```