### PR TITLE
Include action indices when loading data

### DIFF
--- a/qcodes/data/data_array.py
+++ b/qcodes/data/data_array.py
@@ -1,6 +1,7 @@
 import numpy as np
 import collections
 import warnings
+from typing import Iterable
 
 from qcodes.utils.helpers import DelegateAttributes, full_class, warn_units, \
     smooth
@@ -125,7 +126,12 @@ class DataArray(DelegateAttributes):
         self.unit = unit
         self.array_id = array_id
         self.is_setpoint = is_setpoint
-        self.action_indices = action_indices
+
+        if isinstance(action_indices, Iterable):
+            # Cast action indices into tuple if possible
+            self.action_indices = tuple(action_indices)
+        else:
+            self.action_indices = action_indices
         self.set_arrays = set_arrays
 
         self._preset = False

--- a/qcodes/data/gnuplot_format.py
+++ b/qcodes/data/gnuplot_format.py
@@ -144,6 +144,7 @@ class GNUPlotFormat(Formatter):
             else:
                 set_array = DataArray(label=labels[i], array_id=array_id,
                                       set_arrays=set_arrays, shape=set_shape,
+                                      action_indices=snap.get('action_indices', ()),
                                       is_setpoint=True, snapshot=snap)
                 set_array.init_data()
                 data_set.add_array(set_array)
@@ -164,6 +165,7 @@ class GNUPlotFormat(Formatter):
             else:
                 data_array = DataArray(label=labels[i], array_id=array_id,
                                        set_arrays=set_arrays, shape=shape,
+                                       action_indices=snap.get('action_indices', ()),
                                        snapshot=snap)
                 data_array.init_data()
                 data_set.add_array(data_array)


### PR DESCRIPTION
Currently DataArrays of loaded datasets do not have their action indices specified.
We also cast action indices into a tuple where possible. This is because the action indices loaded from the metadata is a list by default