### PR TITLE
fix: Keep clim working if array contains both colormaps and 2 lineplots

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -457,11 +457,13 @@ class MatPlot(BasePlot):
         pc = ax.pcolormesh(*args, **kwargs)
 
         # Scale colors from clim kwarg, or otherwise from min(z) and max(z)
-        data_arrays = [data_array.get_array() for data_array in ax.collections]
+        data_arrays = [data_array.get_array() for data_array in ax.collections
+                       if data_array.get_array() is not None]
         if clim is None:
             # Get color limits as min/max of all existing plotted 2D arrays
-            clim = [np.min([np.nanmin(data_array) for data_array in data_arrays if data_array is not None]),
-                    np.max([np.nanmax(data_array) for data_array in data_arrays if data_array is not None])]
+            # Note that any line plots will show up as None, and so we filter it out
+            clim = [np.min([np.nanmin(data_array) for data_array in data_arrays]),
+                    np.max([np.nanmax(data_array) for data_array in data_arrays])]
 
         # Update color limits for all plotted 2D arrays
         for mesh in ax.collections:

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -460,8 +460,8 @@ class MatPlot(BasePlot):
         data_arrays = [data_array.get_array() for data_array in ax.collections]
         if clim is None:
             # Get color limits as min/max of all existing plotted 2D arrays
-            clim = [np.min([np.nanmin(data_array) for data_array in data_arrays]),
-                    np.max([np.nanmax(data_array) for data_array in data_arrays])]
+            clim = [np.min([np.nanmin(data_array) for data_array in data_arrays if data_array is not None]),
+                    np.max([np.nanmax(data_array) for data_array in data_arrays if data_array is not None])]
 
         # Update color limits for all plotted 2D arrays
         for mesh in ax.collections:


### PR DESCRIPTION
If a plot contains both lineplots and color plots, MatPlot crashes when trying to extract the color limits.
This PR fixes this issue