### PR TITLE
Feature/only load dataset metadata

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -82,7 +82,7 @@ def new_data(location=None, loc_record=None, name=None, overwrite=False,
     return DataSet(location=location, io=io, **kwargs)
 
 
-def load_data(location=None, formatter=None, io=None):
+def load_data(location=None, formatter=None, io=None, load_arrays=True):
     """
     Load an existing DataSet.
 
@@ -102,6 +102,8 @@ def load_data(location=None, formatter=None, io=None):
             says the root data directory is the current working directory, ie
             where you started the python session.
 
+        load_arrays (bool): Whether to load data arrays or only metadata
+
     Returns:
         A new ``DataSet`` object loaded with pre-existing data.
     """
@@ -111,7 +113,10 @@ def load_data(location=None, formatter=None, io=None):
 
     data = DataSet(location=location, formatter=formatter, io=io)
     data.read_metadata()
-    data.read()
+
+    if load_arrays:
+        data.read()
+
     return data
 
 class DataSet(DelegateAttributes):


### PR DESCRIPTION
This allows loading of a dataset's metadata without actually reading arrays.
Good for quickly searching through datasets

## Usage: 
```load_data(data_path, load_arrays=False)```