### PR TITLE
Fix logging widget timestamp

### DIFF
--- a/qcodes/widgets/logging_widget.py
+++ b/qcodes/widgets/logging_widget.py
@@ -69,7 +69,7 @@ class LoggingWidget(logging.StreamHandler):
             return
 
         # Add message to stack
-        timestamp = time.strftime('%H:%m:%S')
+        timestamp = time.strftime('%H:%M:%S')
         message = f'{timestamp} - {sender}: {msg}'
         options = list(self.widget.options)
         options = [message] + options


### PR DESCRIPTION
A string formatting bug caused the logging widget to output the month instead of minute