### PR TITLE
Feature: ignore 'cmap' kwarg for lineplots

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -351,7 +351,7 @@ class MatPlot(BasePlot):
         if 'label' not in kwargs and isinstance(y, DataArray):
             kwargs['label'] = y.label
 
-        for lineplot_kwarg in ['clim']:
+        for lineplot_kwarg in ['clim', 'cmap']:
             kwargs.pop(lineplot_kwarg, None)
 
         # NOTE(alexj)stripping out subplot because which subplot we're in is


### PR DESCRIPTION
Fixes the following error:

```
arr1d = np.zeros(10)
arr2d = np.zeros((10,10))
MatPlot(arr2d, arr1d)  # This works fine
MatPlot(arr2d, arr1d, cmap='bwr)  # This fails because 'cmap' is also passed to the 1D plot
```
