### PR TITLE
Feature: allow a parameter and linear sweep args to be passed to Sweep

### DIFF
--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -1,6 +1,7 @@
 import sys
 import numpy as np
 from typing import List, Tuple, Union, Sequence, Dict, Any, Callable
+from collections import Iterable
 import threading
 from time import sleep
 import traceback
@@ -740,7 +741,7 @@ class Sweep:
 
         if isinstance(parameter_sequence, Parameter):
             sequence = parameter_sequence.sweep(start=start, stop=stop, step=step, num=num)
-        elif isinstance(parameter_sequence, SweepValues):
+        elif isinstance(parameter_sequence, Iterable):
             if not (start is None and stop is None and step is None and num is None):
                 raise ValueError("If sequence is provided, sweep arguments are ignored.")
             sequence = parameter_sequence

--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -729,13 +729,24 @@ def running_measurement() -> Measurement:
 
 
 class Sweep:
-    def __init__(self, sequence, name=None, unit=None):
+    def __init__(self, parameter_sequence, start=None, stop=None, step=None,
+                 num=None, name=None, unit=None):
         if running_measurement() is None:
             raise RuntimeError("Cannot create a sweep outside a Measurement")
 
         # Properties for the data array
         self.name = name
         self.unit = unit
+
+        if isinstance(parameter_sequence, Parameter):
+            sequence = parameter_sequence.sweep(start=start, stop=stop, step=step, num=num)
+        elif isinstance(parameter_sequence, SweepValues):
+            if not (start is None and stop is None and step is None and num is None):
+                raise ValueError("If sequence is provided, sweep arguments are ignored.")
+            sequence = parameter_sequence
+        else:
+            raise ValueError("Data type not understood, expected Parameter or SweepValues"
+                             f" but got {type(parameter_sequence)}")
 
         self.sequence = sequence
         self.dimension = len(running_measurement().loop_shape)


### PR DESCRIPTION
This enables the following:
```python
with Measurement('test') as msmt:
   for k in Sweep(param, 0, 10, num=33):
       msmt.measure(other_param)
```

Rather than the rather clunky way of doing:
`for k in Sweep(param.sweep(0, 10, num=33)):`

The parameter name `parameter_sequence` is a bit gross, but I think it's more user friendly to just pass either a parameter or a sequence as the first arg, the other args could be pushed into kwargs if need be.