### PR TITLE
Fix: rescale axis after drawing plot

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -388,12 +388,12 @@ class MatPlot(BasePlot):
                         ax.dataLim = bbox
                 ax.autoscale()
 
-        self.rescale_axis()
         # Set internal flag to ensure that the full figure is redrawn.
         # If unset, calling canvas.draw from a separate thread may not draw
         # all components
         self.fig.canvas._force_full = True
         self.fig.canvas.draw()
+        self.rescale_axis()
 
     def _draw_plot(self, ax, y, x=None, fmt=None, subplot=1,
                    xlabel=None,


### PR DESCRIPTION
Prevents the formatter from bugging out after the plot is updated.
This resulted in the axis being modified after the label and scale was determined with rescale_axis.