### PR TITLE
Add 'restore' option to  Sweep to automatically restore previous value when finishing a loop

### DIFF
--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -1210,7 +1210,7 @@ class Sweep:
             action_indices[-1] = 0
             msmt.action_indices = tuple(action_indices)
         except StopIteration:  # Reached end of iteration
-            if self.revert:
+            if self.restore:
                 if isinstance(self.sequence, SweepValues):
                     msmt.unmask(self.sequence.parameter)
                 else:

--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -1121,8 +1121,8 @@ class Sweep:
         unit: unit of sweep. Not needed if a Parameter is passed
         reverse: Sweep over sequence in opposite order.
             The data is also stored in reverse.
-        revert: Masks the state of a parameter automatically before sweeping it,
-                then restores the original value after exiting the loop.
+        restore: Stores the state of a parameter before sweeping it,
+            then restores the original value upon exiting the loop.
 
     Examples:
         ```
@@ -1134,7 +1134,7 @@ class Sweep:
             for param_val in Sweep(p.
         ```
     """
-    def __init__(self, sequence, name=None, unit=None, reverse=False, revert=False):
+    def __init__(self, sequence, name=None, unit=None, reverse=False, restore=False):
         if running_measurement() is None:
             raise RuntimeError("Cannot create a sweep outside a Measurement")
 
@@ -1150,7 +1150,7 @@ class Sweep:
         self.loop_index = None
         self.iterator = None
         self.reverse = reverse
-        self.revert = revert
+        self.restore = restore
 
         msmt = running_measurement()
         if msmt.action_indices in msmt.set_arrays:
@@ -1164,11 +1164,11 @@ class Sweep:
                 "Cannot create a Sweep while another measurement "
                 "is already running in a different thread."
             )
-        if self.revert:
+        if self.restore:
             if isinstance(self.sequence, SweepValues):
                 running_measurement().mask(self.sequence.parameter, self.sequence.parameter.get())
             else:
-                raise NotImplementedError("Unable to revert non-parameter values.")
+                raise NotImplementedError("Unable to restore non-parameter values.")
         if self.reverse:
             self.loop_index = len(self.sequence) - 1
             self.iterator = iter(self.sequence[::-1])

--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -1121,6 +1121,8 @@ class Sweep:
         unit: unit of sweep. Not needed if a Parameter is passed
         reverse: Sweep over sequence in opposite order.
             The data is also stored in reverse.
+        mask: Masking the parameter automatically restores the original value
+             the parameter held before sweeping it.
 
     Examples:
         ```
@@ -1132,7 +1134,7 @@ class Sweep:
             for param_val in Sweep(p.
         ```
     """
-    def __init__(self, sequence, name=None, unit=None, reverse=False):
+    def __init__(self, sequence, name=None, unit=None, reverse=False, mask=False):
         if running_measurement() is None:
             raise RuntimeError("Cannot create a sweep outside a Measurement")
 
@@ -1148,6 +1150,7 @@ class Sweep:
         self.loop_index = None
         self.iterator = None
         self.reverse = reverse
+        self.mask = mask
 
         msmt = running_measurement()
         if msmt.action_indices in msmt.set_arrays:
@@ -1161,7 +1164,11 @@ class Sweep:
                 "Cannot create a Sweep while another measurement "
                 "is already running in a different thread."
             )
-
+        if self.mask:
+            if isinstance(self.sequence, SweepValues):
+                running_measurement().mask(self.sequence.parameter, self.sequence.parameter.get())
+            else:
+                raise NotImplementedError("Unable to mask non-parameter values.")
         if self.reverse:
             self.loop_index = len(self.sequence) - 1
             self.iterator = iter(self.sequence[::-1])
@@ -1203,6 +1210,12 @@ class Sweep:
             action_indices[-1] = 0
             msmt.action_indices = tuple(action_indices)
         except StopIteration:  # Reached end of iteration
+            if self.mask:
+                if isinstance(self.sequence, SweepValues):
+                    msmt.unmask(self.sequence.parameter)
+                else:
+                    # TODO: Check what other iterators might be able to be masked
+                    pass
             self.exit_sweep()
 
         if isinstance(self.sequence, SweepValues):

--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -1121,8 +1121,8 @@ class Sweep:
         unit: unit of sweep. Not needed if a Parameter is passed
         reverse: Sweep over sequence in opposite order.
             The data is also stored in reverse.
-        mask: Masking the parameter automatically restores the original value
-             the parameter held before sweeping it.
+        revert: Masks the state of a parameter automatically before sweeping it,
+                then restores the original value after exiting the loop.
 
     Examples:
         ```
@@ -1134,7 +1134,7 @@ class Sweep:
             for param_val in Sweep(p.
         ```
     """
-    def __init__(self, sequence, name=None, unit=None, reverse=False, mask=False):
+    def __init__(self, sequence, name=None, unit=None, reverse=False, revert=False):
         if running_measurement() is None:
             raise RuntimeError("Cannot create a sweep outside a Measurement")
 
@@ -1150,7 +1150,7 @@ class Sweep:
         self.loop_index = None
         self.iterator = None
         self.reverse = reverse
-        self.mask = mask
+        self.revert = revert
 
         msmt = running_measurement()
         if msmt.action_indices in msmt.set_arrays:
@@ -1164,11 +1164,11 @@ class Sweep:
                 "Cannot create a Sweep while another measurement "
                 "is already running in a different thread."
             )
-        if self.mask:
+        if self.revert:
             if isinstance(self.sequence, SweepValues):
                 running_measurement().mask(self.sequence.parameter, self.sequence.parameter.get())
             else:
-                raise NotImplementedError("Unable to mask non-parameter values.")
+                raise NotImplementedError("Unable to revert non-parameter values.")
         if self.reverse:
             self.loop_index = len(self.sequence) - 1
             self.iterator = iter(self.sequence[::-1])
@@ -1210,7 +1210,7 @@ class Sweep:
             action_indices[-1] = 0
             msmt.action_indices = tuple(action_indices)
         except StopIteration:  # Reached end of iteration
-            if self.mask:
+            if self.revert:
                 if isinstance(self.sequence, SweepValues):
                     msmt.unmask(self.sequence.parameter)
                 else:


### PR DESCRIPTION
When constructing large measurements that sweep multiple parameters, it may arise that you want to be able to reset a parameter to its original value after performing a sweep, such as with a DC gate scan.
```python
with Measurement('dc_scan') as msmt:
   msmt.mask(DG1, DG1())
   for _ in Sweep(DG1.sweep(0, 1, num=100)):
      # measure something
   msmt.unmask(DG1)
   msmt.mask(DG2, DG2())
   for _ in Sweep(DG2.sweep(0, 1, num=100)):
      # measure something 
   msmt.unmask(DG2)
   # etc.
```
This is quite tedious, manually masking and unmasking parameters before and after each loop. This can also lead to measurements becoming unintentionally dynamic, for example:

```python
with Measurement('nested_dc_scan') as msmt:
   for _ in Sweep(TG.sweep(1.5, 1.8, num=100)):
      for _ in Sweep(SPL.sweep(window=200e-3, num=10)):
         # measure something

```
One might think that SPL will scan over a 200 mV range from where it's set at the beginning of the experiment, but after each iteration over the TG values, the window will shift as the final setpoint of SPL is 200e-3, and so a new window is generated about this point.

To answer these issues, I've added a simple flag `restore` to the Sweep class, which automatically masks and unmasks parameter values. Other Sweep values (such as a list) will raise a `NotImplementedError`.

--- 


```python
from qcodes.measurement import *
from qcodes.instrument.parameter import Parameter

masked_parameter = Parameter('masked', get_cmd=None, set_cmd=None)
unmasked_parameter = Parameter('unmasked', get_cmd=None, set_cmd=None)

masked_parameter(42)
unmasked_parameter(61)
with Measurement('test_sweep_masking'):
    print(f"before sweep, masked parameter is {masked_parameter()}")
    for _ in Sweep(masked_parameter.sweep(0, 1, num=100), restore=True):
        msmt.measure(masked_parameter)
    print(f"after sweep, masked parameter is {masked_parameter()}")
    for _ in Sweep(np.linspace(1, 100, 34), mask=False):
        msmt.measure(1, name='dummy')
        
    print(f"before sweep, masked parameter is {unmasked_parameter()}")
    for _ in Sweep(unmasked_parameter.sweep(0, 1, num=100), restore=False):
        msmt.measure(unmasked_parameter)
    print(f"after sweep, unmasked parameter is {unmasked_parameter()}")
    
```
Output:
```
before sweep, masked parameter is 42
after sweep, masked parameter is 42
before sweep, masked parameter is 61
after sweep, unmasked parameter is 1.0

```