### PR TITLE
Hotfix/Improve representation of Timings

### DIFF
--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -1,5 +1,6 @@
 import builtins
 import io
+import pprint
 import json
 import logging
 import math
@@ -808,7 +809,7 @@ class PerformanceTimer():
         return self._timing_to_str(val)
 
     def __repr__(self):
-        return repr(self._timings_to_str(self.timings))
+        return pprint.pformat(self._timings_to_str(self.timings), indent=2)
 
     def clear(self):
         self.timings.clear()


### PR DESCRIPTION
Improves printing of timings to
```
{ 'acquisition': '534+-646 ms',
  'save_traces': '23.3+-21.5 ms',
  'setup': { 'ATS_interface': '64+-2.1 ms',
             'arbstudio_interface': '8.72+-9.86 s',
             'fast_AWG_interface': '2.89+-1.54 s',
             'microwave_interface': '6.35+-1.84 ms',
             'pulseblaster_DDS_interface': '16.3+-0.18 ms',
             'pulseblaster_interface': '527+-631 ms'},
  'start': { 'arbstudio_interface': '796+-13.2 ms',
             'fast_AWG_interface': '32+-48.5 ms',
             'microwave_interface': '650+-68.5 us',
             'pulseblaster_DDS_interface': '11+-0.369 ms',
             'pulseblaster_interface': '220+-68.2 us'},
  'stop': { 'ATS_interface': '232+-98.5 us',
            'arbstudio_interface': '355+-9.34 ms',
            'chip_interface': '135+-27.3 us',
            'fast_AWG_interface': '66.7+-105 ms',
            'microwave_interface': '618+-43.6 us',
            'pulseblaster_DDS_interface': '10.2+-3.09 ms',
            'pulseblaster_interface': '189+-15.4 us'},
  'update_oscilloscope': '1.56+-3.88 ms'}
```


Old version:
```
{'stop': {'ATS_interface': '234+-99.4 us',
  'chip_interface': '135+-27.2 us',
  'arbstudio_interface': '355+-9.36 ms',
  'pulseblaster_DDS_interface': '10.2+-3.07 ms',
  'microwave_interface': '618+-43.4 us',
  'fast_AWG_interface': '69.5+-108 ms',
  'pulseblaster_interface': '189+-15.4 us'},
 'setup': {'ATS_interface': '64+-2.1 ms',
  'arbstudio_interface': '8.72+-9.86 s',
  'microwave_interface': '6.35+-1.84 ms',
  'fast_AWG_interface': '2.89+-1.54 s',
  'pulseblaster_interface': '527+-631 ms',
  'pulseblaster_DDS_interface': '16.3+-0.18 ms'},
 'start': {'arbstudio_interface': '796+-13.2 ms',
  'microwave_interface': '650+-68.5 us',
  'fast_AWG_interface': '32+-48.5 ms',
  'pulseblaster_interface': '220+-68.2 us',
  'pulseblaster_DDS_interface': '11+-0.369 ms'},
 'acquisition': '639+-798 ms',
 'update_oscilloscope': '2.54+-6.04 ms',
 'save_traces': '23.3+-21.5 ms'}
```