### PR TITLE
Enable dictionary access to set arrays in datasets

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -219,7 +219,10 @@ class DataSet(DelegateAttributes):
         if key in self.arrays:
             return self.arrays[key]
         else:
-            return self.get_array(key)
+            try:
+                return self.get_array(key)
+            except RuntimeError as e:
+                return self.get_array(key, set_arrays=True)
 
     def _ipython_key_completions_(self):
         """Tab completion for IPython, i.e. the data arrays """


### PR DESCRIPTION
I'm sure this was deliberate, but I think the edge cases where this might cause confusion are minimal enough, and people should know what's in their datasets anyway.

This PR allows you to get the set_arrays from a dataset using dictionary keys, the same way you can with measured values.
If there happens to be a duplicate key for a measured value and setpoint, the measured value is returned.