### PR TITLE
Feature: add argument to MatPlot that automatically removes empty plots

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -155,6 +155,11 @@ class MatPlot(BasePlot):
             specifies the index of the matplotlib figure window to use. If None
             then open a new window
 
+        remove_empty_subplots: boolean
+            If True, after creating a figure with subplots, any subplots that
+            are empty are removed. This is not recommended for interactive data
+            viewing, but might be desirable to remove visual clutter.
+
         **kwargs: passed along to MatPlot.add() to add the first data trace
     """
 
@@ -164,7 +169,7 @@ class MatPlot(BasePlot):
 
     def __init__(self, *args, figsize=None, interval=1, subplots=None, num=None,
                  colorbar=True, sharex=False, sharey=False, gridspec_kw=None,
-                 actions=[], **kwargs):
+                 actions=[], remove_empty_subplots=False, **kwargs):
         super().__init__(interval)
 
         if subplots is None:
@@ -187,6 +192,11 @@ class MatPlot(BasePlot):
                 self[k].add(arg, colorbar=colorbar, **kwargs)
         if args:
             self.rescale_axis()
+
+        if remove_empty_subplots:
+            for ax in self:
+                if not ax.collections and not ax.lines:
+                    ax.remove()
 
         self.tight_layout()
         if any(any(map(_is_active_data_array, arg))


### PR DESCRIPTION
Before:
```python
MatPlot(*np.random.rand(7, 10))
```
![Figure 4](https://user-images.githubusercontent.com/7358024/101345419-1a968f00-38db-11eb-9e0c-715e7b71f546.png)

After:
```python
MatPlot(*np.random.rand(7, 10), remove_empty_subplots=True)
```
![Figure 3](https://user-images.githubusercontent.com/7358024/101345428-1e2a1600-38db-11eb-9c97-5ff76ab57472.png)
