### PR TITLE
Driver/picoscope

### DIFF
--- a/qcodes/instrument_drivers/picotech/__init__.py
+++ b/qcodes/instrument_drivers/picotech/__init__.py
@@ -1,0 +1,1 @@
+from .picoscope import PicoScope

--- a/qcodes/instrument_drivers/picotech/picoscope.py
+++ b/qcodes/instrument_drivers/picotech/picoscope.py
@@ -1,14 +1,21 @@
+import numpy as np
+import time
+from typing import Callable, List
+from matplotlib import pyplot as plt
+from functools import partial, wraps
+import ctypes
+
 from qcodes.instrument.base import Instrument
 from qcodes.instrument.channel import InstrumentChannel, ChannelList
 from qcodes.utils.validators import *
 from qcodes.instrument.parameter import Parameter
-from typing import Callable, List
+from qcodes import MatPlot
 
-import ctypes
-import numpy as np
-from picosdk.ps3000a import ps3000a as picosdk
+from picosdk.ps3000a import ps3000a as ps
 from picosdk.functions import adc2mV, assert_pico_ok
-import time
+from picosdk.constants import PICO_STATUS_LOOKUP
+
+
 
 def error_check(value, method_name=None):
     """Check if returned value after a set is an error code or not.
@@ -20,18 +27,24 @@ def error_check(value, method_name=None):
     Raises:
         AssertionError if returned value is an error code.
     """
-    assert isinstance(value, (str, bool, np.ndarray)) or (int(value) >= 0), \
-        f'Error in call to picosdk.{method_name}, error code {value}'
+    assert isinstance(value, (str, bool, np.ndarray)) or (
+        int(value) >= 0
+    ), f"Error in call to picosdk.{method_name}, error code {value}"
 
 
 def with_error_check(fun):
     @wraps(fun)
     def error_check_wrapper(*args, **kwargs):
         value = fun(*args, **kwargs)
-        error_check(value, f'Error calling {fun.__name__} with args {kwargs}. '
-                           f'Return value = {value}')
+        error_check(
+            value,
+            f"Error calling {fun.__name__} with args {kwargs}. "
+            f"Return value = {value}",
+        )
         return value
+
     return error_check_wrapper
+
 
 class PicoParameter(Parameter):
     """Picoscope parameter designed to send picosdk commands.
@@ -57,16 +70,19 @@ class PicoParameter(Parameter):
             perform a set, so it does not call any picosdk function.
         **kwargs: Additional kwargs passed to Parameter
     """
-    def __init__(self,
-                 name: str,
-                 parent: Union[Instrument, InstrumentChannel] = None,
-                 get_cmd: Callable = None,
-                 get_function: Callable = None,
-                 set_cmd: Callable = False,
-                 set_function: Callable = None,
-                 set_args: List[str] = None,
-                 initial_value=None,
-                 **kwargs):
+
+    def __init__(
+        self,
+        name: str,
+        parent: Union[Instrument, InstrumentChannel] = None,
+        get_cmd: Callable = None,
+        get_function: Callable = None,
+        set_cmd: Callable = False,
+        set_function: Callable = None,
+        set_args: List[str] = None,
+        initial_value=None,
+        **kwargs,
+    ):
         self.get_cmd = get_cmd
         self.get_function = get_function
 
@@ -82,6 +98,7 @@ class PicoParameter(Parameter):
             if self.val_mapping is not None:
                 initial_value = self.val_mapping[initial_value]
             self._save_val(initial_value)
+            self.raw_value = initial_value
 
     def set_raw(self, val):
         if self.set_cmd is not False:
@@ -106,11 +123,15 @@ class PicoParameter(Parameter):
             # Evaluate the set function with the necessary set parameter values
             if isinstance(self.parent, InstrumentChannel):
                 # Also pass the channel id
-                return_val = self.set_function(self.parent.parent._chandle, picosdk.PS3000A_CHANNEL[f'PS3000A_CHANNEL_{self.parent.id}'], *set_vals)
+                return_val = self.set_function(
+                    self.parent.parent._chandle,
+                    ps.PS3000A_CHANNEL[f"PS3000A_CHANNEL_{self.parent.id}"],
+                    *set_vals,
+                )
             else:
                 return_val = self.set_function(self.parent._chandle, *set_vals)
             # Check if the returned value is an error
-            method_name = self.set_function.__func__.__name__
+            method_name = self.set_function.__name__
             error_check(return_val, method_name=method_name)
         else:
             # Do nothing, value is saved
@@ -131,116 +152,173 @@ class PicoParameter(Parameter):
 class ScopeChannel(InstrumentChannel):
     """Picoscope channel
 
-        Args:
-            parent: Parent Picoscope instrument
-            name: channel name (e.g. 'chA')
-            id: channel id (e.g. 1)
-            **kwargs: Additional kwargs passed to InstrumentChannel
-        """
+    Args:
+        parent: Parent Picoscope instrument
+        name: channel name (e.g. 'chA')
+        id: channel id (e.g. 1)
+        **kwargs: Additional kwargs passed to InstrumentChannel
+    """
 
     def __init__(self, parent: Instrument, name: str, id: int, **kwargs):
         super().__init__(parent=parent, name=name, **kwargs)
 
         self.id = id
-        self.enabled = PicoParameter('enabled',
-                                     initial_value=True,
-                                     vals=Bool(),
-                                     set_function=picosdk.ps3000aSetChannel,
-                                     set_args=['enabled', 'type', 'range', 'analogue_offset'])
+        self.enabled = PicoParameter(
+            "enabled",
+            initial_value=True,
+            vals=Bool(),
+            set_function=ps.ps3000aSetChannel,
+            set_args=["enabled", "coupling", "range", "offset"],
+        )
 
-        self.type = PicoParameter('type',
-                                     initial_value='DC',
-                                     val_mapping=picosdk.PICO_COUPLING,
-                                     set_function=picosdk.ps3000aSetChannel,
-                                     set_args=['enabled', 'type', 'range', 'analogue_offset'])
+        self.coupling = PicoParameter(
+            "coupling",
+            initial_value="DC",
+            val_mapping=ps.PICO_COUPLING,
+            set_function=ps.ps3000aSetChannel,
+            set_args=["enabled", "coupling", "range", "offset"],
+        )
 
-        self.range = PicoParameter('range',
-                                  initial_value='PS3000A_2V',
-                                  val_mapping=picosdk.PS3000A_RANGE,
-                                  set_function=picosdk.ps3000aSetChannel,
-                                  set_args=['enabled', 'type', 'range', 'analogue_offset'])
+        self.range = PicoParameter(
+            "range",
+            initial_value="PS3000A_2V",
+            val_mapping=ps.PS3000A_RANGE,
+            set_function=ps.ps3000aSetChannel,
+            set_args=["enabled", "coupling", "range", "offset"],
+        )
 
-        self.analogue_offset = PicoParameter('analogue_offset',
-                                   initial_value=0,
-                                   vals=Numbers(),
-                                   # get_function=picosdk.ps3000aGetAnalogueOffset,
-                                   set_function=picosdk.ps3000aSetChannel,
-                                   set_args=['enabled', 'type', 'range', 'analogue_offset'])
+        self.offset = PicoParameter(
+            "offset",
+            initial_value=0,
+            vals=Numbers(),
+            # get_function=picosdk.ps3000aGetAnalogueOffset,
+            set_function=ps.ps3000aSetChannel,
+            set_args=["enabled", "coupling", "range", "offset"],
+        )
 
-    def add_parameter(self, name: str, parameter_class: type=PicoParameter, **kwargs):
+    def add_parameter(self, name: str, parameter_class: type = PicoParameter, **kwargs):
         """Use PicoParameter by default"""
-        super().add_parameter(name=name, parameter_class=parameter_class, parent=self, **kwargs)
-
+        super().add_parameter(
+            name=name, parameter_class=parameter_class, parent=self, **kwargs
+        )
 
 
 class PicoScope(Instrument):
-    def add_parameter(self, name: str, parameter_class: type=PicoParameter, **kwargs):
-        """Use PicoParameter by default"""
-        super().add_parameter(name=name, parameter_class=parameter_class, parent=self, **kwargs)
+    # Create chandle and status ready for use
+    _chandle = ctypes.c_int16()
+    channel_names = ["A", "B", "C", "D"]
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name='picoscope', **kwargs):
         super().__init__(name, **kwargs)
 
-        self.channel_names = ['A', 'B', 'C', 'D']
-        self.buffers = {ch : None for ch in self.channel_names}
-        # Create chandle and status ready for use
-        self._chandle = ctypes.c_int16()
-        status = {}
-
+        self.buffers = {ch: None for ch in self.channel_names}
 
         # Open PicoScope 3000 Series device
-        status["openunit"] = picosdk.ps3000aOpenUnit(ctypes.byref(self._chandle), None)
+        self.initialize_driver()
+
+        # Define channels
+        channels = ChannelList(self, name="channels", chan_type=ScopeChannel)
+        for ch in self.channel_names:
+            channel = ScopeChannel(self, name=f"ch{ch}", id=ch)
+            setattr(self, f"ch{ch}", channel)
+            channels.append(channel)
+
+        self.add_submodule("channels", channels)
+
+        self.initialize_channels()
+
+        self._raw_single_buffers = {}
+        self._raw_buffers = {}
+
+        self.points_per_trace = Parameter(set_cmd=None, initial_value=1000)
+        self.samples = Parameter(set_cmd=None, initial_value=10)
+
+    @property
+    def active_channels(self):
+        return [ch for ch in self.channels if ch.enabled()]
+
+    @property
+    def active_channel_ids(self):
+        return [ch.id for ch in self.active_channels]
+
+    def close(self):
+        status = {}
+        # Stops the scope data acquisition
+        # Handle = chandle
+        status["stop"] = ps.ps3000aStop(self._chandle)
+        assert_pico_ok(status["stop"])
+
+        # Closes the unit
+        # Handle = chandle
+        status["close"] = ps.ps3000aCloseUnit(self._chandle)
+        assert_pico_ok(status["close"])
+        super().close()
+
+    def add_parameter(self, name: str, parameter_class: type = PicoParameter, **kwargs):
+        """Use PicoParameter by default"""
+        super().add_parameter(
+            name=name, parameter_class=parameter_class, parent=self, **kwargs
+        )
+
+    def initialize_driver(self):
+        """Open PicoScope 3000 Series device"""
+        status = {}
+        status["openunit"] = ps.ps3000aOpenUnit(ctypes.byref(self._chandle), None)
         try:
             assert_pico_ok(status["openunit"])
         except:  # PicoNotOkError:
 
-                powerStatus = status["openunit"]
+            powerStatus = status["openunit"]
 
-                if powerStatus == 286:
-                    status["changePowerSource"] = picosdk.ps3000aChangePowerSource(self._chandle, powerStatus)
-                elif powerStatus == 282:
-                    status["changePowerSource"] = picosdk.ps3000aChangePowerSource(self._chandle, powerStatus)
-                else:
-                    raise
-
-                assert_pico_ok(status["changePowerSource"])
-
-        channels = ChannelList(self,
-                               name='channels',
-                               chan_type=ScopeChannel)
-
-        for ch in self.channel_names:
-            channel = ScopeChannel(self, name=f'ch{ch}', id=ch)
-            setattr(self, f'ch{ch}', channel)
-            channels.append(channel)
-
-        self.add_submodule('channels', channels)
-
-        # self.initialize_driver()
-
-
-    def initialize_driver(self):
-        analogue_offset = 0.0
-        channel_range = picosdk.PS3000A_RANGE['PS3000A_2V']
-        status = {}
-        for ch in self.channels:
-            status[f"setCh{ch}"] = picosdk.ps3000aSetChannel(self._chandle,
-                                                    picosdk.PS3000A_CHANNEL[f'PS3000A_CHANNEL_{ch}'],
-                                                    True, #enable
-                                                    picosdk.PS3000A_COUPLING['PS3000A_DC'],
-                                                    channel_range,
-                                                    analogue_offset)
-            assert_pico_ok(status[f"setCh{ch}"])
+            if powerStatus == 286:
+                status["changePowerSource"] = ps.ps3000aChangePowerSource(
+                    self._chandle, powerStatus
+                )
+            elif powerStatus == 282:
+                status["changePowerSource"] = ps.ps3000aChangePowerSource(
+                    self._chandle, powerStatus
+                )
+            else:
+                raise
+        assert_pico_ok(status["changePowerSource"])
         return status
 
-    def initialize_buffers(self, buffer_size, num_buffers):
+    def initialize_channels(self):
+        """Initialize picoscope channels (enable, coupling, range, offset)"""
         status = {}
+        for ch in self.channels:
+            #  specifies whether an input channel is to be enabled, its input coupling type, voltage range and analog offset.
+            channel_status = ps.ps3000aSetChannel(
+                self._chandle,
+                ps.PS3000A_CHANNEL[f"PS3000A_CHANNEL_{ch.id}"],
+                ch.enabled.raw_value,  # enable channel
+                ch.coupling.raw_value,  # DC coupling
+                ch.range.raw_value,  # Set channel range
+                ch.offset.raw_value,  # DC offset
+            )
+
+            assert_pico_ok(channel_status)
+            status[ch.name] = PICO_STATUS_LOOKUP[channel_status]
+        return status
+
+    def setup_buffers(self, num_buffers, buffer_size, memory_segment=0):
+        """Initializes buffers (number of buffers and buffer size)"""
+        status = {}
+
+        totalSamples = buffer_size * num_buffers
+
         # Create buffers ready for assigning pointers for data collection
-        self._raw_buffers = {ch: np.zeros(shape=(num_buffers, buffer_size), dtype=np.int16) for ch in self.channels}
+        self._raw_buffers = {
+            ch.id: np.zeros(shape=totalSamples, dtype=np.int16)
+            for ch in self.active_channels
+        }
+        self._raw_single_buffers = {
+            ch.id: np.zeros(shape=buffer_size, dtype=np.int16)
+            for ch in self.active_channels
+        }
+        self.buffers = {}
 
-        memory_segment = 0
-
-        # Set data buffer location for data collection from channel A
+        # Set data buffer location for data collection
         # handle = chandle
         # source = PS3000A_CHANNEL_A = 0
         # pointer to buffer max = ctypes.byref(bufferAMax)
@@ -249,111 +327,259 @@ class PicoScope(Instrument):
         # segment index = 0
         # ratio mode = PS3000A_RATIO_MODE_NONE = 0
         for ch in self.channels:
-            status[f"setDataBuffers{ch}"] = picosdk.ps3000aSetDataBuffers(self._chandle,
-                                                                     picosdk.PS3000A_CHANNEL[f'PS3000A_CHANNEL_{ch}'],
-                                                                     self._raw_buffers[ch].ctypes.data_as(ctypes.POINTER(ctypes.c_int16)),
-                                                                     None,
-                                                                     buffer_size,
-                                                                     memory_segment,
-                                                                     picosdk.PS3000A_RATIO_MODE['PS3000A_RATIO_MODE_NONE'])
-            assert_pico_ok(status[f"setDataBuffers{ch}"])
+            channel_status = ps.ps3000aSetDataBuffers(
+                self._chandle,
+                ps.PS3000A_CHANNEL[f"PS3000A_CHANNEL_{ch.id}"],
+                self._raw_single_buffers[ch.id].ctypes.data_as(ctypes.POINTER(ctypes.c_int16)),
+                None,
+                buffer_size,
+                memory_segment,
+                ps.PS3000A_RATIO_MODE["PS3000A_RATIO_MODE_NONE"],
+            )
+            assert_pico_ok(channel_status)
+            status[ch.name] = PICO_STATUS_LOOKUP[channel_status]
         return status
 
+    def setup_trigger(self):
+        # Sets up single trigger
+        # Handle = Chandle
+        # Source = ps3000A_channel_B = 0
+        # Enable = 0
+        # Threshold = 1024 ADC counts
+        # Direction = ps3000A_Falling = 3
+        # Delay = 0
+        # autoTrigger_ms = 1000
+        trigger_status = ps.ps3000aSetSimpleTrigger(self._chandle, 1, 0, 1024, 3, 0, 1000)
+        assert_pico_ok(trigger_status)
+
+
+    streaming_info = {}
     def begin_streaming(self):
         status = {}
 
-        sample_interval = ctypes.c_int32(250)
-        sample_units = picosdk.PS3000A_TIME_UNITS['PS3000A_US']
+        totalSamples = self.samples() * self.points_per_trace()
+
+        self.setup_buffers(num_buffers=self.samples(), buffer_size=self.points_per_trace(), memory_segment=0)
+
+        # Begin streaming mode:
+        sampleInterval = ctypes.c_int32(250)
+        sampleUnits = ps.PS3000A_TIME_UNITS['PS3000A_US']
         # We are not triggering:
-        max_pre_trigger_samples = 0
-        auto_stop_on = True
+        maxPreTriggerSamples = 0
+        autoStopOn = 1
         # No downsampling:
-        downsample_ratio = 1
-        total_samples = max([np.product(buf.shape) for buf in self._raw_buffers.values()])
-        buffer_size = max([buf.shape[-1] for buf in self._raw_buffers.values()])
-        print(f"Total samples = {total_samples}, buffer_size = {buffer_size}")
-        status["runStreaming"] = picosdk.ps3000aRunStreaming(self._chandle,
-                                                        ctypes.byref(sample_interval),
-                                                        sample_units,
-                                                        max_pre_trigger_samples,
-                                                        total_samples,
-                                                        auto_stop_on,
-                                                        downsample_ratio,
-                                                        picosdk.PS3000A_RATIO_MODE['PS3000A_RATIO_MODE_NONE'],
-                                                        buffer_size)
+        downsampleRatio = 1
+        status["runStreaming"] = ps.ps3000aRunStreaming(self._chandle,
+                                                        ctypes.byref(sampleInterval),
+                                                        sampleUnits,
+                                                        maxPreTriggerSamples,
+                                                        totalSamples,
+                                                        autoStopOn,
+                                                        downsampleRatio,
+                                                        ps.PS3000A_RATIO_MODE['PS3000A_RATIO_MODE_NONE'],
+                                                        self.points_per_trace())
         assert_pico_ok(status["runStreaming"])
 
-        actual_sample_interval = sample_interval.value
-        actual_sample_interval_ns = actual_sample_interval * 1000
+        actualSampleInterval = sampleInterval.value
+        self.streaming_info['actualSampleIntervalNs'] = actualSampleInterval * 1000
 
-        print("Capturing at sample interval %s ns" % actual_sample_interval_ns)
+        print("Capturing at sample interval %s ns" % self.streaming_info['actualSampleIntervalNs'])
 
-        # We need a big buffer, not registered with the driver, to keep our complete capture in.
-        self.buffers = {ch : np.zeros(shape=total_samples, dtype=np.int16) for ch in self.channels}
-        next_sample = 0
-        auto_stop_outer = False
-        was_called_back = False
+        self.streaming_info['nextSample'] = 0
+        self.streaming_info['autoStopOuter'] = False
+        self.streaming_info['wasCalledBack'] = False
 
-
-        def streaming_callback(mydickt, handle, num_samples, startIndex, overflow, triggerAt, triggered, auto_stop, param):
-            next_sample = mydickt['next_sample']
-            auto_stop_outer = mydickt['auto_stop_outer']
-            was_called_back = mydickt['was_called_back']
-            # global next_sample, auto_stop_outer, was_called_back
-            was_called_back = True
-            destEnd = next_sample + num_samples
-            sourceEnd = startIndex + num_samples
-            for ch in self.channels:
-                self.buffers[ch][next_sample:destEnd] = self._raw_buffers[ch].flatten()[startIndex:sourceEnd]
-
-            next_sample += num_samples
-            if auto_stop:
-                auto_stop_outer = True
-
-            mydickt['next_sample'] = next_sample
-            mydickt['auto_stop_outer'] = auto_stop_outer
-            mydickt['was_called_back'] = was_called_back
-
-        from functools import partial
-        mydickt = dict(next_sample=next_sample, auto_stop_outer=auto_stop_outer, was_called_back=was_called_back)
         # Convert the python function into a C function pointer.
-        c_callback = picosdk.StreamingReadyType(partial(streaming_callback, mydickt))
+        cFuncPtr = ps.StreamingReadyType(self.streaming_callback)
 
-
-        mydickt['next_sample'] = next_sample
-        mydickt['auto_stop_outer'] = auto_stop_outer
         # Fetch data from the driver in a loop, copying it out of the registered buffers and into our complete one.
-        while mydickt['next_sample'] < total_samples and not auto_stop_outer:
-            mydickt['was_called_back'] = False
-            status["getStreamingLastestValues"] = picosdk.ps3000aGetStreamingLatestValues(self._chandle, c_callback, None)
-            if not was_called_back:
+        while self.streaming_info['nextSample'] < totalSamples and not self.streaming_info['autoStopOuter']:
+            wasCalledBack = False
+            status["getStreamingLastestValues"] = ps.ps3000aGetStreamingLatestValues(self._chandle, cFuncPtr, None)
+            if not wasCalledBack:
                 # If we weren't called back by the driver, this means no data is ready. Sleep for a short while before trying
                 # again.
                 time.sleep(0.01)
 
         print("Done grabbing values.")
-        return status
+
+        # Stop the scope
+        # handle = self._chandle
+        status["stop"] = ps.ps3000aStop(self._chandle)
+        assert_pico_ok(status["stop"])
+
+        buffers = self.process_data()
+        return buffers
+
+    def streaming_callback(self, handle, noOfSamples, startIndex, overflow, triggerAt, triggered, autoStop, param):
+        self.streaming_info['wasCalledBack'] = True
+        self.streaming_info['points_per_callback'] = noOfSamples
+
+        nextSample = self.streaming_info['nextSample']
+        destEnd = nextSample + noOfSamples
+        sourceEnd = startIndex + noOfSamples
+
+        for ch in self.active_channel_ids:
+            self._raw_buffers[ch][nextSample:destEnd] = self._raw_single_buffers[ch][startIndex:sourceEnd]
+        self.streaming_info['nextSample'] += noOfSamples
+
+        if autoStop:
+            self.streaming_info['autoStopOuter'] = True
 
     def process_data(self):
         status = {}
-        total_samples = max([np.product(buf.shape) for buf in self._raw_buffers])
-        channel_range = picosdk.PS3000A_RANGE['PS3000A_2V']
-        sample_interval = ctypes.c_int32(250)
-        actual_sample_interval = sample_interval.value
-        actual_sample_interval_ns = actual_sample_interval * 1000
-
         # Find maximum ADC count value
         # handle = chandle
         # pointer to value = ctypes.byref(maxADC)
-        max_adc = ctypes.c_int16()
-        status["maximumValue"] = picosdk.ps3000aMaximumValue(self._chandle, ctypes.byref(max_adc ))
+        maxADC = ctypes.c_int16()
+        status["maximumValue"] = ps.ps3000aMaximumValue(self._chandle, ctypes.byref(maxADC))
         assert_pico_ok(status["maximumValue"])
 
         # Convert ADC counts data to mV
-        scaled_data = {}
-        for ch in self.channels:
-            scaled_data[ch] = adc2mV(self.buffers[ch], channel_range, max_adc)
+        for ch in self.active_channels:
+            buffer_list = np.array(adc2mV(self._raw_buffers[ch.id], ch.range.raw_value, maxADC))
+            buffer_list /= 1e3  # mV to V
+            self.buffers[ch.id] = np.reshape(buffer_list, (self.samples(), self.points_per_trace()))
 
-        # Create time data
-        time = np.linspace(0, (total_samples) * actual_sample_interval_ns, total_samples)
-        return time, scaled_data
+        return self.buffers
+
+    def plot_traces(self):
+        plot = MatPlot(subplots=len(self.buffers))
+        t_list = np.arange(self.points_per_trace()) * self.streaming_info['actualSampleIntervalNs'] / 1e9
+        samples = np.arange(self.samples(), dtype=float)
+        for k, (ch, buffer) in enumerate(self.buffers.items()):
+            plot[k].add(buffer, x=t_list, y=samples)
+
+            plot[k].set_title(f'Channel {ch}')
+
+    def acquisition(self):
+        samples = 10
+        pre_trigger_points = 40000
+        points_per_trace = 40000
+
+        status = {}
+
+        # Setting the number of sample to be collected
+        total_points_per_trace = pre_trigger_points + points_per_trace
+        ctotal_points_per_trace = ctypes.c_int32(total_points_per_trace)  # C type
+
+        self.setup_trigger()
+
+        # Gets timebase information
+        # Handle = chandle
+        # Timebase = 2 = timebase
+        # Nosample = maxsamples
+        # TimeIntervalNanoseconds = ctypes.byref(timeIntervalns)
+        # MaxSamples = ctypes.byref(returnedMaxSamples)
+        # Segement index = 0
+        timebase = 2
+        timeIntervalns = ctypes.c_float()
+        returnedMaxSamples = ctypes.c_int16()
+        status["GetTimebase"] = ps.ps3000aGetTimebase2(self._chandle, timebase, total_points_per_trace, ctypes.byref(timeIntervalns), 1, ctypes.byref(returnedMaxSamples), 0)
+        assert_pico_ok(status["GetTimebase"])
+
+        # Set number of memory segments, should be at least equal to number of samples (i.e. traces).
+        # Handle = Chandle
+        # nSegments = 10
+        # nMaxSamples = ctypes.byref(cmaxSamples)
+        status["MemorySegments"] = ps.ps3000aMemorySegments(self._chandle, samples, ctypes.byref(ctotal_points_per_trace))
+        assert_pico_ok(status["MemorySegments"])
+
+        # sets number of samples (i.e. traces)
+        status["SetNoOfCaptures"] = ps.ps3000aSetNoOfCaptures(self._chandle, samples)
+        assert_pico_ok(status["SetNoOfCaptures"])
+
+        # Starts the block capture
+        # Handle = self._chandle
+        # Number of prTriggerSamples
+        # Number of postTriggerSamples
+        # Timebase = 2 = 4ns (see Programmer's guide for more information on timebases)
+        # time indisposed ms = None (This is not needed within the example)
+        # Segment index = 0
+        # LpRead = None
+        # pParameter = None
+        status["runblock"] = ps.ps3000aRunBlock(self._chandle, pre_trigger_points, points_per_trace, timebase, 1, None, 0, None, None)
+        assert_pico_ok(status["runblock"])
+
+        # Collect data into arrays
+        min_buffers = []
+        max_buffers = []
+        for k in range(samples):
+            # Create buffers ready for assigning pointers for data collection
+            bufferAMax = np.empty(total_points_per_trace, dtype=np.dtype('int16'))
+            bufferAMin = np.empty(total_points_per_trace, dtype=np.dtype('int16')) # used for downsampling which isn't in the scope of this example
+            min_buffers.append(bufferAMin)
+            max_buffers.append(bufferAMax)
+
+            # Setting the data buffer location for data collection from channel A
+            # Handle = Chandle
+            # source = ps3000A_channel_A = 0
+            # Buffer max = ctypes.byref(bufferAMax)
+            # Buffer min = ctypes.byref(bufferAMin)
+            # Buffer length = maxsamples
+            # Segment index = 0
+            # Ratio mode = ps3000A_Ratio_Mode_None = 0
+            status["SetDataBuffers"] = ps.ps3000aSetDataBuffers(self._chandle, 0, bufferAMax.ctypes.data, bufferAMin.ctypes.data, total_points_per_trace, 0, 0)
+            assert_pico_ok(status["SetDataBuffers"])
+
+        # Creates a overlow location for data
+        overflow = (ctypes.c_int16 * 10)()
+        # Creates converted types maxsamples
+        ctotal_points_per_trace = ctypes.c_int32(total_points_per_trace)
+
+        # Checks data collection to finish the capture
+        ready = ctypes.c_int16(0)
+        check = ctypes.c_int16(0)
+        while ready.value == check.value:
+            status["isReady"] = ps.ps3000aIsReady(self._chandle, ctypes.byref(ready))
+
+        # Handle = self._chandle
+        # noOfSamples = ctypes.byref(cmaxSamples)
+        # fromSegmentIndex = 0
+        # ToSegmentIndex = 9
+        # DownSampleRatio = 0
+        # DownSampleRatioMode = 0
+        # Overflow = ctypes.byref(overflow)
+        status["GetValuesBulk"] = ps.ps3000aGetValuesBulk(self._chandle, ctypes.byref(ctotal_points_per_trace), 0, 9, 1, 0, ctypes.byref(overflow))
+        assert_pico_ok(status["GetValuesBulk"])
+
+        # Handle = self._chandle
+        # Times = Times = (ctypes.c_int16*10)() = ctypes.byref(Times)
+        # Timeunits = TimeUnits = ctypes.c_char() = ctypes.byref(TimeUnits)
+        # Fromsegmentindex = 0
+        # Tosegementindex = 9
+        Times = (ctypes.c_int16*10)()
+        TimeUnits = ctypes.c_char()
+        status["GetValuesTriggerTimeOffsetBulk"] = ps.ps3000aGetValuesTriggerTimeOffsetBulk64(self._chandle, ctypes.byref(Times), ctypes.byref(TimeUnits), 0, 9)
+        assert_pico_ok(status["GetValuesTriggerTimeOffsetBulk"])
+
+        # Finds the max ADC count
+        # Handle = self._chandle
+        # Value = ctype.byref(maxADC)
+        maxADC = ctypes.c_int16()
+        status["maximumValue"] = ps.ps3000aMaximumValue(self._chandle, ctypes.byref(maxADC))
+        assert_pico_ok(status["maximumValue"])
+
+        # Converts ADC from channel A to mV
+        channel = self.chA
+        buffers = [adc2mV(buffer_ADC, channel.range.raw_value, maxADC) for buffer_ADC in max_buffers]
+
+        # Stops the scope
+        # Handle = chandle
+        status["stop"] = ps.ps3000aStop(self._chandle)
+        assert_pico_ok(status["stop"])
+
+        # Creates the time data
+        time = np.linspace(0, (ctotal_points_per_trace.value) * timeIntervalns.value, ctotal_points_per_trace.value)
+
+        # Plots the data from channel A onto a graph
+
+        fig, ax = plt.subplots()
+        for buffer in buffers:
+            plt.plot(time, buffer)
+        plt.xlabel('Time (ns)')
+        plt.ylabel('Voltage (mV)')
+        plt.show()
+
+        # Displays the staus returns
+        return buffers

--- a/qcodes/instrument_drivers/picotech/picoscope.py
+++ b/qcodes/instrument_drivers/picotech/picoscope.py
@@ -178,7 +178,7 @@ class PicoScope(Instrument):
         """Use PicoParameter by default"""
         super().add_parameter(name=name, parameter_class=parameter_class, parent=self, **kwargs)
 
-    def __init__(self, name, postpone_open=False, **kwargs):
+    def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
 
         self.channel_names = ['A', 'B', 'C', 'D']
@@ -189,11 +189,10 @@ class PicoScope(Instrument):
 
 
         # Open PicoScope 3000 Series device
-        if not postpone_open:
-            status["openunit"] = picosdk.ps3000aOpenUnit(ctypes.byref(self._chandle), None)
-            try:
-                assert_pico_ok(status["openunit"])
-            except:  # PicoNotOkError:
+        status["openunit"] = picosdk.ps3000aOpenUnit(ctypes.byref(self._chandle), None)
+        try:
+            assert_pico_ok(status["openunit"])
+        except:  # PicoNotOkError:
 
                 powerStatus = status["openunit"]
 

--- a/qcodes/instrument_drivers/picotech/picoscope.py
+++ b/qcodes/instrument_drivers/picotech/picoscope.py
@@ -1,0 +1,347 @@
+from qcodes.instrument.base import Instrument
+from qcodes.instrument.channel import InstrumentChannel, ChannelList
+from qcodes.utils.validators import *
+from qcodes.instrument.parameter import Parameter
+
+import ctypes
+import numpy as np
+from picosdk.ps3000a import ps3000a as picosdk
+from picosdk.functions import adc2mV, assert_pico_ok
+import time
+
+def error_check(value, method_name=None):
+    """Check if returned value after a set is an error code or not.
+
+    Args:
+        value: value to test.
+        method_name: Name of called picosdk method, used for error message
+
+    Raises:
+        AssertionError if returned value is an error code.
+    """
+    assert isinstance(value, (str, bool, np.ndarray)) or (int(value) >= 0), \
+        f'Error in call to picosdk.{method_name}, error code {value}'
+
+
+def with_error_check(fun):
+    @wraps(fun)
+    def error_check_wrapper(*args, **kwargs):
+        value = fun(*args, **kwargs)
+        error_check(value, f'Error calling {fun.__name__} with args {kwargs}. '
+                           f'Return value = {value}')
+        return value
+    return error_check_wrapper
+
+class PicoParameter(Parameter):
+    """Picoscope parameter designed to send picosdk commands.
+
+    This parameter can function as a standard parameter, but can also be
+    associated with a specific picosdk function.
+
+    Args:
+        name: Parameter name
+        parent: Picoscope Instrument or instrument channel
+            In case of a channel, it should have an id between 1 and n_channels.
+        get_cmd: Standard optional Parameter get function
+        get_function: picosdk function to be called when getting the
+            parameter value. If set, get_cmd must be None.
+        set_cmd: Standard optional Parameter set function
+        set_function: picosdk function to be called when setting the
+            parameter value. If set, set_cmd must be None.
+        set_args: Optional ancillary parameter names that are passed to
+            set_function. Some picosdk functions need to pass
+            multiple parameters simultaneously. If set, the name of this
+            parameter must also be included in the appropriate index.
+        initial_value: initial value for the parameter. This does not actually
+            perform a set, so it does not call any picosdk function.
+        **kwargs: Additional kwargs passed to Parameter
+    """
+    def __init__(self,
+                 name: str,
+                 parent: Union[Instrument, InstrumentChannel] = None,
+                 get_cmd: Callable = None,
+                 get_function: Callable = None,
+                 set_cmd: Callable = False,
+                 set_function: Callable = None,
+                 set_args: List[str] = None,
+                 initial_value=None,
+                 **kwargs):
+        self.get_cmd = get_cmd
+        self.get_function = get_function
+
+        self.set_cmd = set_cmd
+        self.set_function = set_function
+        self.set_args = set_args
+
+        super().__init__(name=name, parent=parent, **kwargs)
+
+        if initial_value is not None:
+            # We set the initial value here to ensure that it does not call
+            # the set_raw method the first time
+            if self.val_mapping is not None:
+                initial_value = self.val_mapping[initial_value]
+            self._save_val(initial_value)
+
+    def set_raw(self, val):
+        if self.set_cmd is not False:
+            if self.set_cmd is not None:
+                return self.set_cmd(val)
+            else:
+                return
+        elif self.set_function is not None:
+            if self.set_args is None:
+                set_vals = [val]
+            else:
+                # Convert set args, which are parameter names, to their
+                # corresponding parameter values
+                set_vals = []
+                for set_arg in self.set_args:
+                    if set_arg == self.name:
+                        set_vals.append(val)
+                    else:
+                        # Get the current value of the parameter
+                        set_vals.append(getattr(self.parent, set_arg).raw_value)
+
+            # Evaluate the set function with the necessary set parameter values
+            if isinstance(self.parent, InstrumentChannel):
+                # Also pass the channel id
+                return_val = self.set_function(self.parent.id, *set_vals)
+            else:
+                return_val = self.set_function(*set_vals)
+            # Check if the returned value is an error
+            method_name = self.set_function.__func__.__name__
+            error_check(return_val, method_name=method_name)
+        else:
+            # Do nothing, value is saved
+            pass
+
+    def get_raw(self):
+        if self.get_cmd is not None:
+            return self.get_cmd()
+        elif self.get_function is not None:
+            if isinstance(self.parent, InstrumentChannel):
+                return self.get_function(self.parent.id)
+            else:
+                return self.get_function()
+        else:
+            return self.get_latest(raw=True)
+
+
+class ScopeChannel(InstrumentChannel):
+    """Picoscope channel
+
+        Args:
+            parent: Parent Picoscope instrument
+            name: channel name (e.g. 'chA')
+            id: channel id (e.g. 1)
+            **kwargs: Additional kwargs passed to InstrumentChannel
+        """
+
+    def __init__(self, parent: Instrument, name: str, id: int, **kwargs):
+        super().__init__(parent=parent, name=name, **kwargs)
+
+        self.id = id
+        self.enabled = PicoParameter('enabled',
+                                     initial_value=True,
+                                     vals=Bool(),
+                                     set_function=picosdk.ps300aSetChannel,
+                                     set_args=['type', 'range', 'analogue_offset'])
+
+        self.type = PicoParameter('type',
+                                     initial_value='DC',
+                                     vals=Enum(**picosdk.PICO_COUPLING),
+                                     set_function=picosdk.ps300aSetChannel,
+                                     set_args=['enabled', 'range', 'analogue_offset'])
+
+        self.range = PicoParameter('range',
+                                  initial_value=True,
+                                  vals=Enum(**picosdk.PICO_VOLTAGE_RANGE),
+                                  set_function=picosdk.ps300aSetChannel,
+                                  set_args=['enabled', 'type', 'analogue_offset'])
+
+        self.analogue_offset = PicoParameter('analogue_offset',
+                                   initial_value=True,
+                                   vals=Numbers(),
+                                   # get_function=picosdk.ps3000aGetAnalogueOffset,
+                                   set_function=picosdk.ps300aSetChannel,
+                                   set_args=['enabled', 'type', 'range'])
+
+    def add_parameter(self, name: str, parameter_class: type=PicoParameter, **kwargs):
+        """Use PicoParameter by default"""
+        super().add_parameter(name=name, parameter_class=parameter_class, parent=self, **kwargs)
+
+
+
+class PicoScope(Instrument):
+    def add_parameter(self, name: str, parameter_class: type=PicoParameter, **kwargs):
+        """Use PicoParameter by default"""
+        super().add_parameter(name=name, parameter_class=parameter_class, parent=self, **kwargs)
+
+    def __init__(self, name, **kwargs):
+        self.channels = ['A', 'B', 'C', 'D']
+        self.buffers = {ch : None for ch in self.channels}
+        # Create chandle and status ready for use
+        self._chandle = ctypes.c_int16()
+        status = {}
+
+
+        # Open PicoScope 3000 Series device
+        status["openunit"] = ps.ps3000aOpenUnit(ctypes.byref(self._chandle), None)
+        try:
+            assert_pico_ok(status["openunit"])
+        except:  # PicoNotOkError:
+
+            powerStatus = status["openunit"]
+
+            if powerStatus == 286:
+                status["changePowerSource"] = ps.ps3000aChangePowerSource(self._chandle, powerStatus)
+            elif powerStatus == 282:
+                status["changePowerSource"] = ps.ps3000aChangePowerSource(self._chandle, powerStatus)
+            else:
+                raise
+
+            assert_pico_ok(status["changePowerSource"])
+
+
+
+        self.initialize_driver()
+        super().__init__(name, **kwargs)
+
+    def initialize_driver(self):
+        analogue_offset = 0.0
+        channel_range = ps.PS3000A_RANGE['PS3000A_2V']
+        status = {}
+        for ch in self.channels:
+            status[f"setCh{ch}"] = ps.ps3000aSetChannel(self._chandle,
+                                                    ps.PS3000A_CHANNEL[f'PS3000A_CHANNEL_{ch}'],
+                                                    True, #enable
+                                                    ps.PS3000A_COUPLING['PS3000A_DC'],
+                                                    channel_range,
+                                                    analogue_offset)
+            assert_pico_ok(status[f"setCh{ch}"])
+        return status
+
+    def initialize_buffers(self, buffer_size, num_buffers):
+        status = {}
+        # Create buffers ready for assigning pointers for data collection
+        self._raw_buffers = {ch: np.zeros(shape=(num_buffers, buffer_size), dtype=np.int16) for ch in self.channels}
+
+        memory_segment = 0
+
+        # Set data buffer location for data collection from channel A
+        # handle = chandle
+        # source = PS3000A_CHANNEL_A = 0
+        # pointer to buffer max = ctypes.byref(bufferAMax)
+        # pointer to buffer min = ctypes.byref(bufferAMin)
+        # buffer length = maxSamples
+        # segment index = 0
+        # ratio mode = PS3000A_RATIO_MODE_NONE = 0
+        for ch in self.channels:
+            status[f"setDataBuffers{ch}"] = ps.ps3000aSetDataBuffers(self._chandle,
+                                                                     ps.PS3000A_CHANNEL[f'PS3000A_CHANNEL_{ch}'],
+                                                                     self._raw_buffers[ch].ctypes.data_as(ctypes.POINTER(ctypes.c_int16)),
+                                                                     None,
+                                                                     buffer_size,
+                                                                     memory_segment,
+                                                                     ps.PS3000A_RATIO_MODE['PS3000A_RATIO_MODE_NONE'])
+            assert_pico_ok(status[f"setDataBuffers{ch}"])
+        return status
+
+    def begin_streaming(self):
+        status = {}
+
+        sample_interval = ctypes.c_int32(250)
+        sample_units = ps.PS3000A_TIME_UNITS['PS3000A_US']
+        # We are not triggering:
+        max_pre_trigger_samples = 0
+        auto_stop_on = True
+        # No downsampling:
+        downsample_ratio = 1
+        total_samples = max([np.product(buf.shape) for buf in self._raw_buffers.values()])
+        buffer_size = max([buf.shape[-1] for buf in self._raw_buffers.values()])
+        print(f"Total samples = {total_samples}, buffer_size = {buffer_size}")
+        status["runStreaming"] = ps.ps3000aRunStreaming(self._chandle,
+                                                        ctypes.byref(sample_interval),
+                                                        sample_units,
+                                                        max_pre_trigger_samples,
+                                                        total_samples,
+                                                        auto_stop_on,
+                                                        downsample_ratio,
+                                                        ps.PS3000A_RATIO_MODE['PS3000A_RATIO_MODE_NONE'],
+                                                        buffer_size)
+        assert_pico_ok(status["runStreaming"])
+
+        actual_sample_interval = sample_interval.value
+        actual_sample_interval_ns = actual_sample_interval * 1000
+
+        print("Capturing at sample interval %s ns" % actual_sample_interval_ns)
+
+        # We need a big buffer, not registered with the driver, to keep our complete capture in.
+        self.buffers = {ch : np.zeros(shape=total_samples, dtype=np.int16) for ch in self.channels}
+        next_sample = 0
+        auto_stop_outer = False
+        was_called_back = False
+
+
+        def streaming_callback(mydickt, handle, num_samples, startIndex, overflow, triggerAt, triggered, auto_stop, param):
+            next_sample = mydickt['next_sample']
+            auto_stop_outer = mydickt['auto_stop_outer']
+            was_called_back = mydickt['was_called_back']
+            # global next_sample, auto_stop_outer, was_called_back
+            was_called_back = True
+            destEnd = next_sample + num_samples
+            sourceEnd = startIndex + num_samples
+            for ch in self.channels:
+                self.buffers[ch][next_sample:destEnd] = self._raw_buffers[ch].flatten()[startIndex:sourceEnd]
+
+            next_sample += num_samples
+            if auto_stop:
+                auto_stop_outer = True
+
+            mydickt['next_sample'] = next_sample
+            mydickt['auto_stop_outer'] = auto_stop_outer
+            mydickt['was_called_back'] = was_called_back
+
+        from functools import partial
+        mydickt = dict(next_sample=next_sample, auto_stop_outer=auto_stop_outer, was_called_back=was_called_back)
+        # Convert the python function into a C function pointer.
+        c_callback = ps.StreamingReadyType(partial(streaming_callback, mydickt))
+
+
+        mydickt['next_sample'] = next_sample
+        mydickt['auto_stop_outer'] = auto_stop_outer
+        # Fetch data from the driver in a loop, copying it out of the registered buffers and into our complete one.
+        while mydickt['next_sample'] < total_samples and not auto_stop_outer:
+            mydickt['was_called_back'] = False
+            status["getStreamingLastestValues"] = ps.ps3000aGetStreamingLatestValues(self._chandle, c_callback, None)
+            if not was_called_back:
+                # If we weren't called back by the driver, this means no data is ready. Sleep for a short while before trying
+                # again.
+                time.sleep(0.01)
+
+        print("Done grabbing values.")
+        return status
+
+    def process_data(self):
+        status = {}
+        total_samples = max([np.product(buf.shape) for buf in self._raw_buffers])
+        channel_range = ps.PS3000A_RANGE['PS3000A_2V']
+        sample_interval = ctypes.c_int32(250)
+        actual_sample_interval = sample_interval.value
+        actual_sample_interval_ns = actual_sample_interval * 1000
+
+        # Find maximum ADC count value
+        # handle = chandle
+        # pointer to value = ctypes.byref(maxADC)
+        max_adc = ctypes.c_int16()
+        status["maximumValue"] = ps.ps3000aMaximumValue(self._chandle, ctypes.byref(max_adc ))
+        assert_pico_ok(status["maximumValue"])
+
+        # Convert ADC counts data to mV
+        scaled_data = {}
+        for ch in self.channels:
+            scaled_data[ch] = adc2mV(self.buffers[ch], channel_range, max_adc)
+
+        # Create time data
+        time = np.linspace(0, (total_samples) * actual_sample_interval_ns, total_samples)
+        return time, scaled_data

--- a/qcodes/instrument_drivers/picotech/picoscope_alternative.py
+++ b/qcodes/instrument_drivers/picotech/picoscope_alternative.py
@@ -1,0 +1,434 @@
+import numpy as np
+import logging
+import time
+from typing import Callable, List, Union
+from matplotlib import pyplot as plt
+from functools import partial, wraps
+import numpy as np
+
+from qcodes.instrument.base import Instrument
+from qcodes.instrument.parameter import MultiParameter
+from qcodes.instrument.channel import InstrumentChannel, ChannelList
+from qcodes.utils import validators as vals
+from qcodes.instrument.parameter import Parameter
+from qcodes import MatPlot
+from qcodes.utils.helpers import PerformanceTimer
+
+from picoscope import *
+from picoscope import ps3000a as ps
+
+
+logger = logging.getLogger(__name__)
+
+def error_check(value, method_name=None):
+    """Check if returned value after a set is an error code or not.
+
+    Args:
+        value: value to test.
+        method_name: Name of called picosdk method, used for error message
+
+    Raises:
+        AssertionError if returned value is an error code.
+    """
+    assert isinstance(value, (str, bool, np.ndarray)) or (
+        int(value) >= 0
+    ), f"Error in call to picoscope.ps3000a.{method_name}, error code {value}"
+
+
+def with_error_check(fun):
+    @wraps(fun)
+    def error_check_wrapper(*args, **kwargs):
+        value = fun(*args, **kwargs)
+        error_check(
+            value,
+            f"Error calling {fun.__name__} with args {kwargs}. "
+            f"Return value = {value}",
+        )
+        return value
+
+    return error_check_wrapper
+
+
+class PicoParameter(Parameter):
+    """Picoscope parameter designed to send picosdk commands.
+
+    This parameter can function as a standard parameter, but can also be
+    associated with a specific picosdk function.
+
+    Args:
+        name: Parameter name
+        parent: Picoscope Instrument or instrument channel
+            In case of a channel, it should have an id between 1 and n_channels.
+        get_cmd: Standard optional Parameter get function
+        get_function: picosdk function to be called when getting the
+            parameter value. If set, get_cmd must be None.
+        set_cmd: Standard optional Parameter set function
+        set_function: picosdk function to be called when setting the
+            parameter value. If set, set_cmd must be None.
+        set_args: Optional ancillary parameter names that are passed to
+            set_function. Some picosdk functions need to pass
+            multiple parameters simultaneously. If set, the name of this
+            parameter must also be included in the appropriate index.
+        initial_value: initial value for the parameter. This does not actually
+            perform a set, so it does not call any picosdk function.
+        **kwargs: Additional kwargs passed to Parameter
+    """
+
+    def __init__(
+        self,
+        name: str,
+        parent: Union[Instrument, InstrumentChannel] = None,
+        get_cmd: Callable = None,
+        get_function: Callable = None,
+        set_cmd: Callable = False,
+        set_function: Callable = None,
+        set_args: List[str] = None,
+        initial_value=None,
+        **kwargs,
+    ):
+        self.get_cmd = get_cmd
+        self.get_function = get_function
+
+        self.set_cmd = set_cmd
+        self.set_function = set_function
+        self.set_args = set_args
+
+        super().__init__(name=name, parent=parent, **kwargs)
+
+        if initial_value is not None:
+            # We set the initial value here to ensure that it does not call
+            # the set_raw method the first time
+            if self.val_mapping is not None:
+                initial_value = self.val_mapping[initial_value]
+            self._save_val(initial_value)
+            self.raw_value = initial_value
+
+    def set_raw(self, val):
+        if self.set_cmd is not False:
+            if self.set_cmd is not None:
+                return self.set_cmd(val)
+            else:
+                return
+        elif self.set_function is not None:
+            if self.set_args is None:
+                set_vals = [val]
+            else:
+                # Convert set args, which are parameter names, to their
+                # corresponding parameter values
+                set_vals = []
+                for set_arg in self.set_args:
+                    if set_arg == self.name:
+                        set_vals.append(val)
+                    else:
+                        # Get the current value of the parameter
+                        set_vals.append(getattr(self.parent, set_arg).raw_value)
+
+            # Evaluate the set function with the necessary set parameter values
+            if isinstance(self.parent, InstrumentChannel):
+                # Also pass the channel id
+                return_val = self.set_function(
+                    self.parent.id,
+                    *set_vals,
+                )
+            else:
+                return_val = self.set_function(self.parent._chandle, *set_vals)
+            # Check if the returned value is an error
+            method_name = self.set_function.__name__
+            error_check(return_val, method_name=method_name)
+        else:
+            # Do nothing, value is saved
+            pass
+
+    def get_raw(self):
+        if self.get_cmd is not None:
+            return self.get_cmd()
+        elif self.get_function is not None:
+            if isinstance(self.parent, InstrumentChannel):
+                return self.get_function(self.parent.id)
+            else:
+                return self.get_function()
+        else:
+            return self.get_latest(raw=True)
+
+class PicoAcquisitionParameter(MultiParameter):
+    def __init__(self, instrument, **kwargs):
+        self.instrument = instrument
+        super().__init__(snapshot_value=False,
+                         names=[''], shapes=[()], **kwargs)
+
+    @property
+    def names(self):
+        if self.instrument is None or \
+                not hasattr(self.instrument, 'active_channels')\
+                or self.instrument.active_channels is None:
+            return ['']
+        else:
+            return tuple(['ch{}_signal'.format(ch.id) for ch in
+                          self.instrument.active_channels])
+
+    @names.setter
+    def names(self, names):
+        # Ignore setter since getter is extracted from instrument
+        pass
+
+    @property
+    def labels(self):
+        return self.names
+
+    @labels.setter
+    def labels(self, labels):
+        # Ignore setter since getter is extracted from instrument
+        pass
+
+    @property
+    def units(self):
+        return ['V'] * len(self.names)
+
+    @units.setter
+    def units(self, units):
+        # Ignore setter since getter is extracted from instrument
+        pass
+
+    @property
+    def shapes(self):
+        if hasattr(self.instrument, 'average_mode'):
+            average_mode = self.instrument.average_mode()
+
+            if average_mode == 'point':
+                shape = ()
+            elif average_mode == 'trace':
+                shape = (self.instrument.samples(),)
+            else:
+                shape = (self.instrument.samples(),
+                         self.instrument.points_per_trace())
+            return tuple([shape] * len(self.instrument.active_channels))
+        else:
+            return tuple(() * len(self.names))
+
+    @shapes.setter
+    def shapes(self, shapes):
+        # Ignore setter since getter is extracted from acquisition controller
+        pass
+
+    def get_raw(self):
+        raw_data = self.instrument.acquisition()
+        if self.instrument.average_mode() == 'point':
+            return raw_data.mean()
+        if self.instrument.average_mode() == 'trace':
+            return raw_data.mean(axis=0)
+        else:
+            return raw_data
+
+
+class ScopeChannel(InstrumentChannel):
+    """Picoscope channel
+
+    Args:
+        parent: Parent Picoscope instrument
+        name: channel name (e.g. 'chA')
+        id: channel id (e.g. 1)
+        **kwargs: Additional kwargs passed to InstrumentChannel
+    """
+
+    def __init__(self, parent: Instrument, name: str, id: int, **kwargs):
+        super().__init__(parent=parent, name=name, **kwargs)
+
+        self.id = id
+        self.enabled = PicoParameter(
+            "enabled",
+            initial_value=True,
+            vals=vals.Bool(),
+            set_function=parent.setChannel,
+            set_args=["coupling", "range", "offset", "enabled"],
+        )
+
+        self.coupling = PicoParameter(
+            "coupling",
+            initial_value="DC",
+            vals=vals.Enum(*parent.CHANNEL_COUPLINGS.keys()),
+            set_function=parent.setChannel,
+            set_args=["coupling", "range", "offset", "enabled"],
+        )
+
+        self.range = PicoParameter(
+            "range",
+            initial_value=2, # 2 V range
+            vals=vals.Enum(*[option['rangeV'] for option in parent.CHANNEL_RANGE]),
+            set_function=parent.setChannel,
+            set_args=["coupling", "range", "offset", "enabled"],
+        )
+
+        self.offset = PicoParameter(
+            "offset",
+            initial_value=0,
+            vals=vals.Numbers(),
+            set_function=parent.setChannel,
+            set_args=["coupling", "range", "offset", "enabled"],
+        )
+
+    def add_parameter(self, name: str, parameter_class: type = PicoParameter, **kwargs):
+        """Use PicoParameter by default"""
+        super().add_parameter(
+            name=name, parameter_class=parameter_class, parent=self, **kwargs
+        )
+
+
+class PicoScope(Instrument, ps.PS3000a):
+    channel_names = ["A", "B", "C", "D"]
+
+    def __init__(self, name='picoscope', serialNumber=None, connect=True, **kwargs):
+        """
+
+        Args:
+            name:
+                The name of the instrument.
+            serialNumber:
+                Passed to the picoscope API to locate the instrument
+            connect: Bool
+                When True, opens the instrument automatically. If False, you
+                will need to manually connect by using self.open(serialNumber).
+            **kwargs:
+        """
+        Instrument.__init__(self, name, **kwargs)
+        ps.PS3000a.__init__(self, serialNumber=serialNumber, connect=connect, **kwargs)
+
+
+        self._raw_buffers = {}
+        self.buffers = {ch: None for ch in self.channel_names}
+
+        # Define channels
+        channels = ChannelList(self, name="channels", chan_type=ScopeChannel)
+        for ch in self.channel_names:
+            channel = ScopeChannel(self, name=f"ch{ch}", id=ch)
+            setattr(self, f"ch{ch}", channel)
+            channels.append(channel)
+
+        self.add_submodule("channels", channels)
+
+        self.initialize_channels()
+
+
+        self.points_per_trace = Parameter(set_cmd=None, initial_value=1000, set_parser=lambda x: int(round(x)))
+        self.samples = Parameter(set_cmd=None, initial_value=10, set_parser=lambda x: int(round(x)))
+        self.sample_rate = Parameter(set_cmd=None, initial_value=500e3, set_parser=lambda x: int(round(x)))
+        self.average_mode = Parameter(set_cmd=None, get_cmd=None, vals=vals.Enum('point', 'trace', None))
+
+        # Trigger parameters
+        self.use_trigger = Parameter(set_cmd=None, initial_value=False, vals=vals.Bool())
+        self.trigger_channel = Parameter(
+            set_cmd=None, initial_value='External',
+            vals=vals.Enum(*[ch.id for ch in self.channels], 'External'),
+            # val_mapping={
+            #     **{ch:ch for ch in self.channels},
+            #     'external': ps.PS3000A_CHANNEL[f'PS3000A_EXTERNAL']
+            # }
+        )
+        self.trigger_threshold = Parameter(set_cmd=None, unit='V', initial_value=0.5, vals=vals.Numbers())
+        self.trigger_direction = Parameter(
+            set_cmd=None, initial_value='Rising', vals=vals.Enum(*self.THRESHOLD_TYPE)
+        )
+        self.trigger_delay = Parameter(set_cmd=None, initial_value=0, unit='s')
+        self.autotrigger_ms = Parameter(set_cmd=None, initial_value=0, unit='ms',
+                                        docstring='milliseconds to wait after trigger. 0 means wait indefinitely')
+
+        self.timings = PerformanceTimer()
+
+    @property
+    def active_channels(self):
+        return [ch for ch in self.channels if ch.enabled()]
+
+    @property
+    def active_channel_ids(self):
+        return [ch.id for ch in self.active_channels]
+
+    def close(self):
+        self.stop()
+        ps.PS3000a.close(self)
+        Instrument.close(self)
+
+    def stop(self):
+        ps.PS3000a.stop(self)
+
+    def add_parameter(self, name: str, parameter_class: type = PicoParameter, **kwargs):
+        """Use PicoParameter by default"""
+        super().add_parameter(
+            name=name, parameter_class=parameter_class, parent=self, **kwargs
+        )
+
+    def initialize_channels(self):
+        """Initialize picoscope channels (enable, coupling, range, offset)"""
+        for ch in self.channels:
+            #  specifies whether an input channel is to be enabled, its input coupling type, voltage range and analog offset.
+            self.setChannel(
+                channel=ch.id,
+                enabled=ch.enabled.raw_value,
+                coupling=ch.coupling.raw_value,
+                VRange=ch.range.raw_value,
+                VOffset=ch.offset.raw_value,
+            )
+
+    def initialize_buffers(self):
+        """Initializes buffers (number of buffers and buffer size)"""
+        # Create buffers ready for assigning pointers for data collection
+        self._raw_buffers = {
+            ch.id: np.zeros(shape=(self.samples(), self.points_per_trace()), dtype=np.int16)
+            for ch in self.active_channels
+        }
+        self.buffers = {ch.id: None for ch in self.active_channels} # empty for now
+
+    def setup_block_capture(self):
+        self.setSamplingFrequency(self.sample_rate(), self.points_per_trace())
+        # self.setSimpleTrigger("A", threshold_V=0.5)
+
+        samples_per_segment = self.memorySegments(self.samples())
+        self.setNoOfCaptures(self.samples())
+        self.runBlock()
+
+    def get_data(self):
+        with self.timings.record('wait_for_acquisition'):
+            self.waitReady()
+
+        for ch in self.active_channels:
+            self.getDataRawBulk(ch.id, data=self._raw_buffers[ch.id])
+            self.buffers[ch.id] = self.rawToV(ch.id, self._raw_buffers[ch.id])
+
+    def setup_trigger(self):
+        trigger_channel_id = self.trigger_channel()
+        self.setSimpleTrigger(trigSrc=trigger_channel_id,
+                              enabled=True,
+                              threshold_V=self.trigger_threshold(),
+                              direction=self.trigger_direction(),
+                              delay=self.trigger_delay(),
+                              timeout_ms=self.autotrigger_ms())
+
+    def process_data(self):
+        # Convert ADC counts data to V
+        for ch in self.active_channels:
+            if self.buffers[ch.id] is not None and self.buffers[ch.id].shape == self._raw_buffers[ch.id].shape:
+                # Save memory by passing the already created buffers
+                self.rawToV(ch.id, dataRaw=self._raw_buffers[ch.id], dataV=self.buffers[ch.id])
+            else:
+                self.buffers[ch.id] = np.reshape(self.rawToV(ch.id, self._raw_buffers[ch.id]),
+                                                 newshape=(self.samples(), self.points_per_trace()))
+
+        return self.buffers
+
+    def plot_traces(self):
+        plot = MatPlot(subplots=len(self.buffers))
+        t_list = np.arange(self.points_per_trace(), 1/self.sample_rate())
+        samples = np.arange(self.samples(), dtype=float)
+        for k, (ch, buffer) in enumerate(self.buffers.items()):
+            plot[k].add(buffer, x=t_list, y=samples)
+
+            plot[k].set_title(f'Channel {ch}')
+
+    def acquisition(self):
+        with self.timings.record('setup_trigger'):
+            self.setup_trigger()
+        with self.timings.record('setup_block_capture'):
+            self.setup_block_capture()
+        with self.timings.record('get_data'):
+            self.get_data()
+        with self.timings.record('process_data'):
+            self.process_data()
+        return self.buffers

--- a/qcodes/instrument_drivers/picotech/picoscope_alternative.py
+++ b/qcodes/instrument_drivers/picotech/picoscope_alternative.py
@@ -330,7 +330,7 @@ class PicoScope(Instrument, ps.PS3000a):
         self.trigger_delay = Parameter(set_cmd=None, initial_value=0, unit='s')
         self.autotrigger_ms = Parameter(set_cmd=None, initial_value=0, unit='ms',
                                         docstring='milliseconds to wait after trigger. 0 means wait indefinitely')
-
+        self.buffer_actions = []
         self.timings = PerformanceTimer()
 
     @property
@@ -390,7 +390,6 @@ class PicoScope(Instrument, ps.PS3000a):
 
         for ch in self.active_channels:
             self.getDataRawBulk(ch.id, data=self._raw_buffers[ch.id])
-            self.buffers[ch.id] = self.rawToV(ch.id, self._raw_buffers[ch.id])
 
     def setup_trigger(self):
         trigger_channel_id = self.trigger_channel()
@@ -410,6 +409,8 @@ class PicoScope(Instrument, ps.PS3000a):
             else:
                 self.buffers[ch.id] = np.reshape(self.rawToV(ch.id, self._raw_buffers[ch.id]),
                                                  newshape=(self.samples(), self.points_per_trace()))
+        for buffer_action in self.buffer_actions:
+            buffer_action(self.buffers)
 
         return self.buffers
 


### PR DESCRIPTION
Adds the driver for the Picotech picoscope (works for the 3403D at least).
Requires a different python interface to be installed than the one offered by Picotech (which doesn't work).