### PR TITLE
Make the parameter node `__repr__` more verbose for easier use.

### DIFF
--- a/qcodes/instrument/parameter_node.py
+++ b/qcodes/instrument/parameter_node.py
@@ -192,10 +192,15 @@ class ParameterNode(Metadatable, DelegateAttributes, metaclass=ParameterNodeMeta
         return s
 
     def __repr__(self):
-        repr_str = f'ParameterNode {self} containing '
+        repr_str = f'ParameterNode {str(self) + " " if str(self) else ""}containing '
         if self.parameter_nodes:
-            repr_str += f'{len(self.parameter_nodes)} nodes, '
-        repr_str += f'{len(self.parameters)} parameters'
+            repr_str += f'{len(self.parameter_nodes)} node{"s" if len(self.parameter_nodes) != 1 else ""}:\n'
+            for parameter_node in self.parameter_nodes:
+                repr_str += f'\t{parameter_node}\n'
+        if self.parameters:
+            repr_str += f'{len(self.parameters)} parameter{"s" if len(self.parameters) != 1 else ""}:\n'
+            for parameter in self.parameters:
+                    repr_str += f'\t{parameter}\n'
         return repr_str
 
     def __getattr__(self, attr):


### PR DESCRIPTION
In ipython if you now view the output of a parameter_node, it will not only tell you how many parameter nodes and parameters it has, but what their names are.

e.g. previous output:
`>>> esr_composite_parameter.analyses.ESR`
Output:
```
ParameterNode ESR containing 2 nodes, 1 parameters
```
new output:
`>>> esr_composite_parameter.analyses.ESR`
Output:
```
ParameterNode ESR containing 2 nodes:
	settings
	outputs
1 parameter:
	enabled
```

In the future this might generate a lot of output, but I don't imagine it will be any bigger than what modern datasets look like.  
If this becomes a problem we can re-think the representation then.