### PR TITLE
Change deprecated visa module to pyvisa

### DIFF
--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -3,7 +3,7 @@ from typing import Sequence
 import warnings
 import logging
 
-import visa
+import pyvisa as visa
 import pyvisa.constants as vi_const
 import pyvisa.resources
 

--- a/qcodes/instrument_drivers/Keysight/Keysight_81180A.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_81180A.py
@@ -2,7 +2,7 @@ import array
 from warnings import warn
 from time import sleep, time
 import logging
-import visa
+import pyvisa as visa
 import struct
 
 from qcodes import (

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -1,7 +1,7 @@
 # QCoDeS driver for QDac. Based on Alex Johnson's work.
 
 import time
-import visa
+import pyvisa as visa
 import logging
 import numpy as np
 

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -1,7 +1,7 @@
 # QCoDeS driver for QDac using channels
 
 import time
-import visa
+import pyvisa as visa
 import logging
 import numpy as np
 

--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -1,7 +1,7 @@
 import time
 import logging
 import numpy as np
-import visa  # used for the parity constant
+import pyvisa as visa  # used for the parity constant
 import traceback
 import threading
 

--- a/qcodes/instrument_drivers/cryogenic/CryogenicSMS120C.py
+++ b/qcodes/instrument_drivers/cryogenic/CryogenicSMS120C.py
@@ -10,7 +10,7 @@ This magnet PS driver has been tested with:
 
 """
 
-import visa
+import pyvisa as visa
 import re
 import logging
 import time

--- a/qcodes/instrument_drivers/oxford/ILM200.py
+++ b/qcodes/instrument_drivers/oxford/ILM200.py
@@ -9,7 +9,7 @@
 
 
 from time import sleep
-import visa
+import pyvisa as visa
 import logging
 from qcodes import VisaInstrument
 

--- a/qcodes/instrument_drivers/oxford/IPS120.py
+++ b/qcodes/instrument_drivers/oxford/IPS120.py
@@ -13,7 +13,7 @@ import logging
 from qcodes import VisaInstrument
 from qcodes import validators as vals
 from time import sleep
-import visa
+import pyvisa as visa
 
 
 log = logging.getLogger(__name__)

--- a/qcodes/instrument_drivers/oxford/kelvinox.py
+++ b/qcodes/instrument_drivers/oxford/kelvinox.py
@@ -9,7 +9,7 @@
 
 
 from time import sleep
-import visa
+import pyvisa as visa
 import logging
 import numpy
 from qcodes import VisaInstrument

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch
-import visa
+import pyvisa as visa
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.utils.validators import Numbers
 import warnings


### PR DESCRIPTION
Replace `import visa` with `import pyvisa as visa`, as the former usage is now deprecated in the pyvisa package.