### PR TITLE
Don't finalize dataset if the measurement only contains setpoints

### DIFF
--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -260,6 +260,11 @@ class Measurement:
             # If dataset only contains setpoints, don't finalize dataset.
             if not all([arr.is_setpoint for arr in self.dataset.arrays.values()]):
                 self.dataset.finalize()
+            else:
+                if hasattr(self.dataset.formatter, 'close_file'):
+                    self.dataset.formatter.close_file(self)
+                self.dataset.save_metadata()
+
             self.dataset.active = False
 
             self.log(f'Measurement finished {self.dataset.location}')

--- a/qcodes/measurement.py
+++ b/qcodes/measurement.py
@@ -257,7 +257,9 @@ class Measurement:
 
             t_stop = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             self.dataset.add_metadata({"t_stop": t_stop})
-            self.dataset.finalize()
+            # If dataset only contains setpoints, don't finalize dataset.
+            if not all([arr.is_setpoint for arr in self.dataset.arrays.values()]):
+                self.dataset.finalize()
             self.dataset.active = False
 
             self.log(f'Measurement finished {self.dataset.location}')


### PR DESCRIPTION
If a measurement raises an exception at the start, it will then also fail to finalize the dataset because it doesn't have any measured points, which hides the original error.

Adding this check fixes the problem; this is one of the checkpoints in #98 .